### PR TITLE
Update minter-statefile path for production env.

### DIFF
--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -4,6 +4,8 @@ Sufia.config do |config|
     file_author: :creator
   }
 
+  config.minter_statefile = Rails.env.production? ? '/var/deepbluedata/minter-state' : '/tmp/minter-state'
+
   config.max_days_between_audits = 7
 
   config.max_notifications_for_dashboard = 5


### PR DESCRIPTION
Will prevent issues with ids if /tmp gets cleared.  I'm looking at you Debian.

tl;dr I didn't write a spec for this code.

Testing the config logic is difficult to do as is.  The initializers are loaded once and no amount of arm twisting will get Rails to reload them without breaking. The solution is to extract the config logic into it's own class and run unit tests against that class.  The current config is simple enough that reading it, and doing a manual check with different Rails.env is sufficient.  If the configuration starts to involve more logic, that will have to be extracted into its own class so it can be tested.
