### PR TITLE
Only generate thumbnail derivatives.

### DIFF
--- a/app/models/concerns/umrdr/file_set_behavior.rb
+++ b/app/models/concerns/umrdr/file_set_behavior.rb
@@ -8,5 +8,31 @@ module Umrdr
       'open'
     end
 
+    # Override the derivatives generation to avoid full text and non-thumbnail
+    # generation.
+    def create_derivatives(filename)
+      case mime_type
+      when *self.class.pdf_mime_types
+        Hydra::Derivatives::PdfDerivatives.create(filename,
+                                                  outputs: [{ label: :thumbnail, format: 'jpg',
+                                                              size: '150x150',
+                                                              url: derivative_url('thumbnail') }])
+      when *self.class.office_document_mime_types
+        Hydra::Derivatives::DocumentDerivatives.create(filename,
+                                                       outputs: [{ label: :thumbnail, format: 'jpg',
+                                                                   size: '150x150',
+                                                                   url: derivative_url('thumbnail') }])
+      when *self.class.video_mime_types
+        Hydra::Derivatives::VideoDerivatives.create(filename,
+                                                    outputs: [{ label: :thumbnail, format: 'jpg',
+                                                                size: '150x150',
+                                                                url: derivative_url('thumbnail') }])
+      when *self.class.image_mime_types
+        Hydra::Derivatives::ImageDerivatives.create(filename,
+                                                    outputs: [{ label: :thumbnail, format: 'jpg',
+                                                                size: '150x150',
+                                                                url: derivative_url('thumbnail') }])
+      end
+    end
   end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -4,4 +4,46 @@ describe FileSet do
   it 'is open visibility by default.' do
     expect(subject.visibility).to eq 'open'
   end
+
+  describe "derivative generation" do
+    let(:outputs) do
+      [{ label: :thumbnail, format: 'jpg',
+                  size: '150x150',
+                  url: 'dummy_url' }]
+    end
+    let(:f_name) {'dummy_filename'}
+    let(:fake_class) do
+      Class.new { def create(*args); end; }
+    end
+
+    before do
+      allow(subject).to receive(:derivative_url).and_return("dummy_url")
+    end
+
+    it 'generates only thumbnails from pdfs.' do
+      allow(subject).to receive(:mime_type).and_return('application/pdf')
+      expect(Hydra::Derivatives::FullTextExtract).to_not receive(:create)
+      expect(Hydra::Derivatives::PdfDerivatives).to receive(:create).with(f_name, outputs: outputs)
+      subject.create_derivatives(f_name)
+    end
+
+    it 'generates only thumbnails from document types.' do
+      allow(subject).to receive(:mime_type).and_return('text/rtf')
+      expect(Hydra::Derivatives::FullTextExtract).to_not receive(:create)
+      expect(Hydra::Derivatives::DocumentDerivatives).to receive(:create).with(f_name, outputs: outputs)
+      subject.create_derivatives('dummy_filename')
+    end
+
+    it 'only generates thumbnail from video.' do
+      allow(subject).to receive(:mime_type).and_return('video/mp4')
+      expect(Hydra::Derivatives::VideoDerivatives).to receive(:create).with(f_name, outputs: outputs)
+      subject.create_derivatives('dummy_filename')
+    end
+
+    it 'does not generate audio derivatives.' do
+      allow(subject).to receive(:mime_type).and_return('audio/mp3')
+      expect(Hydra::Derivatives::AudioDerivatives).to_not receive(:create)
+      subject.create_derivatives('dummy_filename')
+    end
+  end
 end


### PR DESCRIPTION
Add spec for derivative generation.
Thumbnails sizes all set to 150x150.