### PR TITLE
Do not permit visibility to be changed from open.

### DIFF
--- a/app/models/concerns/umrdr/file_set_behavior.rb
+++ b/app/models/concerns/umrdr/file_set_behavior.rb
@@ -8,6 +8,10 @@ module Umrdr
       'open'
     end
 
+    def visibility=(value)
+      super('open')
+    end
+
     # Override the derivatives generation to avoid full text and non-thumbnail
     # generation.
     def create_derivatives(filename)

--- a/app/models/concerns/umrdr/generic_work_behavior.rb
+++ b/app/models/concerns/umrdr/generic_work_behavior.rb
@@ -8,5 +8,9 @@ module Umrdr
       'open'
     end
 
+    def visibility=(value)
+      super('open')
+    end
+
   end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -5,6 +5,11 @@ describe FileSet do
     expect(subject.visibility).to eq 'open'
   end
 
+  it 'it cannot be set to anything other than open visibility.' do
+    subject.visibility='restricted'
+    expect(subject.visibility).to eq 'open'
+  end
+
   describe "derivative generation" do
     let(:outputs) do
       [{ label: :thumbnail, format: 'jpg',

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -6,4 +6,9 @@ describe GenericWork do
   it 'is open visibility by default.' do
     expect(subject.visibility).to eq 'open'
   end
+
+  it 'it cannot be set to anything other than open visibility.' do
+    subject.visibility='restricted'
+    expect(subject.visibility).to eq 'open'
+  end
 end


### PR DESCRIPTION
Additionally overriding `visibility=` to prevent the machinery in Hydra::AccessControls from being invoked and assigning any other visibility.

Addresses #14 