### PR TITLE
Set defaults for work with fewer overrides

### DIFF
--- a/app/models/concerns/umrdr/generic_work_behavior.rb
+++ b/app/models/concerns/umrdr/generic_work_behavior.rb
@@ -2,19 +2,8 @@ module Umrdr
   module GenericWorkBehavior
     extend ActiveSupport::Concern
 
-    # Override constructor
-    # Set resource_type to dataset
-    def initialize(attributes_or_id = nil, &_block)
-      super
-      self.resource_type = ['Dataset']
-    end
-
     # Dirty dirty trick to ensure all have 'open' visibility.
     # Can leave all the rest of the Sufia machinery in place.
-    def visibility
-      'open'
-    end
-
     def visibility=(value)
       super('open')
     end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -7,4 +7,12 @@ class GenericWork < ActiveFedora::Base
   validates :creator, presence: { message: 'Your work must have a creator.' }
   validates :date_created, presence: { message: 'Your work must have a date created.' }
   validates :description, presence: { message: 'Your work must have a description.' }
+
+  after_initialize :set_defaults
+
+  def set_defaults
+    return unless new_record?
+    self.resource_type = ['Dataset']
+    self.visibility = 'open'
+  end
 end


### PR DESCRIPTION
No more overriding the constructor.
Fewer dirty hacks.