### PR TITLE
Update git ignore for additional configs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ config/redis.yml
 config/resque-pool.yml
 config/jetty.yml
 config/umich.yml
+config/doi.yml
+config/browse_everything_providers.yml
+config/arkivo.yml
+config/zotero.yml
+config/clients_data/*
 
 # Ignore bundler config.
 /.bundle


### PR DESCRIPTION
Additional configs that may be copied in from the configuration repository need to be ignored so that they do not accidentally get pushed to the public repository.