### PR TITLE
Force default_title to not append controller name for static pages

### DIFF
--- a/app/helpers/curation_concerns_helper.rb
+++ b/app/helpers/curation_concerns_helper.rb
@@ -1,4 +1,17 @@
 module CurationConcernsHelper
   include ::BlacklightHelper
   include CurationConcerns::MainAppHelpers
+
+  def default_page_title
+    text = controller_name.singularize.titleize
+    if action_text = action_name.titleize
+      if text == 'Static'
+        text = action_text
+      else
+        text = "#{action_text} " + text
+      end
+    end
+    construct_page_title(text)
+  end
+
 end


### PR DESCRIPTION
Ensure static pages to not have the "static" controller name appended to their titles. The original behavior is necessary to generate page titles like "New Collection".