### PR TITLE
Standard date format to YYYY-mm-dd.

### DIFF
--- a/config/initializers/curation_concerns.rb
+++ b/config/initializers/curation_concerns.rb
@@ -93,4 +93,4 @@ CurationConcerns.configure do |config|
   # config.analytic_start_date = DateTime.new(2014,9,10)
 end
 
-Date::DATE_FORMATS[:standard] = '%m/%d/%Y'
+Date::DATE_FORMATS[:standard] = '%Y-%m-%d'

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -118,4 +118,4 @@ Sufia.config do |config|
   end
 end
 
-Date::DATE_FORMATS[:standard] = "%m/%d/%Y"
+Date::DATE_FORMATS[:standard] = '%Y-%m-%d'


### PR DESCRIPTION
This mostly affects the `.to_s` calls for rendering dates.