### PR TITLE
Remove patch to build_form after validation fail.

### DIFF
--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -7,11 +7,4 @@ class CurationConcerns::GenericWorksController < ApplicationController
   include Sufia::WorksControllerBehavior
 
   set_curation_concern_type GenericWork
-
-  # override setup_form to add build_form.
-  # Until curation_concerns/#614 is resolved.
-  def setup_form
-    build_form
-    super
-  end
 end


### PR DESCRIPTION
The upstream fix was made call build_form after validation failed.
The patch made by umrdr is now dead code and is removed by this PR.
Closes #67