### PR TITLE
ux change: refer to Generic Works as Works

### DIFF
--- a/app/models/concerns/umrdr/generic_work_behavior.rb
+++ b/app/models/concerns/umrdr/generic_work_behavior.rb
@@ -2,6 +2,10 @@ module Umrdr
   module GenericWorkBehavior
     extend ActiveSupport::Concern
 
+    included do
+      self.human_readable_type = 'Work'
+    end
+
     # Dirty dirty trick to ensure all have 'open' visibility.
     # Can leave all the rest of the Sufia machinery in place.
     def visibility=(value)


### PR DESCRIPTION
"Generic Work" will appear as "Work" in the app. Requires reindex of solr.