### PR TITLE
fix to remove visibility links on access labels

### DIFF
--- a/app/helpers/file_set_helper.rb
+++ b/app/helpers/file_set_helper.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+module FileSetHelper
+  def display_title(fs)
+    fs.to_s
+  end
+
+  def present_terms(presenter, terms = :all, &block)
+    terms = presenter.terms if terms == :all
+    Sufia::PresenterRenderer.new(presenter, self).fields(terms, &block)
+  end
+
+  def display_multiple(value)
+    return if value.nil?
+    auto_link(html_escape(value.join(" | ")))
+  end
+
+  private
+
+  def render_visibility_badge(presenter)
+    render_visibility_label presenter.solr_document
+  end
+end

--- a/app/views/collections/_show_document_list_row.html.erb
+++ b/app/views/collections/_show_document_list_row.html.erb
@@ -1,0 +1,52 @@
+<% id = document.id %>
+<% presenter = document.is_a?(GenericWork) ? Sufia::WorkShowPresenter.new(document, nil) : nil %>
+<tr id="document_<%= id %>" class="<%= cycle("", "zebra") %>">
+  <td>&nbsp;
+    <% if presenter && presenter.processing? %>
+        <i class="glyphicon glyphicon-time <%= 'ss-'+presenter.upload_set_id %>"/>
+    <% elsif current_user and document.depositor != current_user.user_key %>
+        <i class="glyphicon glyphicon-share-alt"/>
+    <% end %>
+  </td>
+  <td>
+    <div class="media">
+      <%= link_to curation_concerns_generic_work_path(document), class: "media-left" do %>
+          <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+      <% end %>
+      <div class="media-body">
+        <h4 class="media-heading">
+          <%= link_to document.title_or_label, curation_concerns_generic_work_path(document), id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %>
+          <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
+        </h4>
+        <%= render_collection_links(document) %>
+      </div>
+    </div>
+  </td>
+  <td class="text-center"><%= document.date_uploaded %> </td>
+  <td class="text-center">
+    <%= render_visibility_label(document) %>
+  </td>
+  <td class="text-center">
+    <%= render partial: 'show_document_list_menu', locals: { id: id } %>
+  </td>
+</tr>
+<tr id="detail_<%= id %>"> <!--  document detail"> -->
+  <td colspan="6">
+    <dl class="expanded-details row">
+      <dt class="col-xs-3 col-lg-2">File Name:</dt>
+      <dd class="col-xs-9 col-lg-4"><%= link_to document.label, curation_concerns_generic_work_path(document) %></dd>
+      <dt class="col-xs-3 col-lg-2">Creator:</dt>
+      <dd class="col-xs-9 col-lg-4"><%= document.creator %></dd>
+      <dt class="col-xs-3 col-lg-2">Depositor:</dt>
+      <dd class="col-xs-9 col-lg-4"><%= link_to_profile document.depositor %></dd>
+      <dt class="col-xs-3 col-lg-2">Edit Access:</dt>
+      <dd class="col-xs-9 col-lg-10">
+        <% if document.edit_groups.present? %>
+            Groups: <%= document.edit_groups.join(', ') %>
+            <br/>
+        <% end %>
+        Users: <%= document.edit_people.join(', ') %>
+      </dd>
+    </dl>
+  </td>
+</tr>

--- a/app/views/my/_index_partials/_list_works.html.erb
+++ b/app/views/my/_index_partials/_list_works.html.erb
@@ -1,0 +1,42 @@
+<tr id="document_<%= document.id %>" class="<%= cycle("", "zebra") %>">
+
+  <td>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%=t("sufia.dashboard.my.sr.batch_checkbox")%></label>
+    <% if presenter.processing? %>
+        <i class="glyphicon glyphicon-time <%= 'ss-'+presenter.upload_set_id %>"/>
+    <% else %>
+        <%= batch_edit_select(document) %>&nbsp;
+    <% end %>
+  </td>
+
+  <td>
+    <div class='media'>
+      <%= link_to curation_concerns_generic_work_path(document), class: 'media-left', 'aria-hidden' => true do %>
+          <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+      <% end %>
+
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to curation_concerns_generic_work_path(document), id: "src_copy_link#{document.id}", class: 'document-title' do %>
+            <span class="sr-only">
+              <%= t("sufia.dashboard.my.sr.show_label") %>
+            </span>
+              <%= document.title_or_label %>
+          <% end %>
+
+          <br />
+          <%= render_collection_links(document) %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class='text-center'><%= document.date_uploaded %></td>
+  <td class='text-center'><%= render_visibility_label document %></td>
+
+  <td class='text-center'>
+    <%= render 'work_action_menu', document: document %>
+  </td>
+</tr>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -144,8 +144,8 @@ en:
     visibility:
       open: "Open Access"
       private: "Private"
-      open_title_attr: "Change the visibility of this resource"
-      private_title_attr: "Change the visibility of this resource"
+      open_title_attr: "Shows the visibility of this resource"
+      private_title_attr: "Shows the visibility of this resource"
     user_profile:
       no_followers: "No one is following you."
       no_following: "You are not following anyone."


### PR DESCRIPTION
contains:
fix to remove visibility links on access labels in
	modified:   app/helpers/file_set_helper.rb
	modified:   app/views/collections/_show_document_list_row.html.erb
	modified:   app/views/my/_index_partials/_list_works.html.erb

changes for workstations development (to be ignored)