### PR TITLE
render select in a manner that behaves well with simple_form/rails

### DIFF
--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -1,5 +1,5 @@
 <% options = RightsService.select_options.dup %>
-<% options.unshift(['- Choose Creative Commons License -', nil]) %>
-<%= f.input :rights, as: :select,
+<%= f.input :rights,
     collection: options,
+    include_blank: '- Choose Creative Commons License - ',
     input_html: { class: 'form-control' } %>


### PR DESCRIPTION
Restored client-side required validation referenced in #123 --- the _rights.html.erb widget needed to be simplified to better rely on simple_form/rails machinery for "blank" select options.