### PR TITLE
Browse everything initial integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
+  gem 'pry'
+  gem 'pry-rails'
+  gem 'pry-byebug'
   gem 'rspec-rails'
   gem 'solr_wrapper', '~> 0.5'
   gem 'fcrepo_wrapper', '~> 0.1'
@@ -51,8 +54,6 @@ group :development do
   gem 'umichwrapper', github: 'mlibrary/umichwrapper', branch: 'master'
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'engine_cart'
-  gem 'pry'
-  gem 'pry-rails'
   gem 'web-console', '~> 2.0'
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,6 +465,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (2.16.0)
@@ -734,6 +737,7 @@ DEPENDENCIES
   mysql2
   poltergeist
   pry
+  pry-byebug
   pry-rails
   puma
   rails (= 4.2.5)

--- a/app/views/curation_concerns/file_sets/upload/_form_fields.html.erb
+++ b/app/views/curation_concerns/file_sets/upload/_form_fields.html.erb
@@ -36,6 +36,8 @@
                     <i class="glyphicon glyphicon-ban-circle"></i>
                     <span>Cancel upload</span>
                 </button>
+		<button type="button" data-toggle="browse-everything" data-route="<%=browse_everything_engine.root_path%>"
+			data-target="#myForm" class="btn btn-large btn-success" id="browse">Browse!</button>
             </div>
             <div class="col-md-5 fileupload-progress">
                 <!-- The global progress bar -->

--- a/config/browse_everything_providers.yml.sample
+++ b/config/browse_everything_providers.yml.sample
@@ -1,0 +1,21 @@
+#
+# To make browse-everything aware of a provider, uncomment the info for that provider and add your API key information.
+# The file_system provider can be a path to any directory on the server where your application is running.
+#
+---
+# file_system:
+#   :home: USE_AT_YOUR_OWN_PERIL
+box:
+  :client_id: YOUR_CLIENT_ID_HERE
+  :client_secret: YOUR_CLIENT_SECRET_HERE
+  :callback: "https://HOSTNAME/RELATIVE_URL_ROOT/browse/connect"
+google_drive:
+  :client_id: YOUR_GOOGLE_DRIVE_CLIENT_ID
+  :client_secret: YOUR_GOOGLE_DRIVE_API_CLIENT_SECRET
+  :callback: "https://HOSTNAME/RELATIVE_URL_ROOT/browse/connect"
+# dropbox:
+#   :app_key: YOUR_DROPBOX_APP_KEY
+#   :app_secret: YOUR_DROPBOX_APP_SECRET
+# sky_drive:
+#   :client_id: YOUR_MS_LIVE_CONNECT_CLIENT_ID
+#   :client_secret: YOUR_MS_LIVE_CONNECT_CLIENT_SECRET

--- a/config/initializers/browse_everything.rb
+++ b/config/initializers/browse_everything.rb
@@ -1,0 +1,13 @@
+# require 'browse_everything'
+
+module BrowseEverything
+  module Driver
+    class Base
+      def callback
+        config[:callback]
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
Includes patch of browse_everything at `config/initializers/browse_everything.rb` to accommodate issue with engine and relative_root_url. 

