### PR TITLE
remove keyword's edit link from show work

### DIFF
--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -2,7 +2,7 @@
   <%= @presenter.attribute_to_html(:creator, catalog_search_link: true ) %>
   <%= @presenter.attribute_to_html(:contributor, label: 'Contributors', catalog_search_link: true) %>
   <%= @presenter.attribute_to_html(:subject, label: 'Discipline', catalog_search_link: true) %>
-  <%= @presenter.attribute_to_html(:tag, label: 'Keywords', catalog_search_link: true) %>
+  <%= @presenter.attribute_to_html(:tag, label: 'Keywords', catalog_search_link: false) %>
   <%= @presenter.attribute_to_html(:publisher) %>
   <%= @presenter.attribute_to_html(:language) %>
 


### PR DESCRIPTION
When a user clicks on the keywords in show work, it gives an error 'tag' not found. The problem is down to CC, where tag is defined as tags in solr:

Few options can be done later to make it a link:
override: https://github.com/projecthydra-labs/curation_concerns/blob/bab2f05e1d1dbbec8366dbf7eace94cb1e49a534/app/renderers/curation_concerns/attribute_renderer.rb

or this: https://github.com/projecthydra-labs/curation_concerns/blob/master/curation_concerns-models/app/models/concerns/curation_concerns/solr_document_behavior.rb#L100

Related PR in Sufia: https://github.com/projecthydra/sufia/pull/1561