### PR TITLE
Add doi minting service and job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ config/doi.yml
 config/browse_everything_providers.yml
 config/arkivo.yml
 config/zotero.yml
+config/ezid.yml
 config/clients_data/*
 
 # Ignore bundler config.

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
 
+# EZID client from Duke
+gem 'ezid-client'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.5'
 # Use sqlite3 as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,8 @@ GEM
       ffi (>= 1.3.0)
     execjs (2.6.0)
     extlib (0.9.16)
+    ezid-client (1.2.0)
+      hashie
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fcrepo_wrapper (0.2.1)
@@ -293,6 +295,7 @@ GEM
       signet (~> 0.7)
     haml (4.0.7)
       tilt
+    hashie (3.4.3)
     htmlentities (4.3.4)
     httmultiparty (0.3.16)
       httparty (>= 0.7.3)
@@ -730,6 +733,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.3)
   engine_cart
+  ezid-client
   fcrepo_wrapper (~> 0.1)
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/jobs/doi_minting_job.rb
+++ b/app/jobs/doi_minting_job.rb
@@ -1,13 +1,23 @@
 class DOIMintingJob < ActiveFedoraIdBasedJob
-  queue_as :handle
+  queue_as :doi_minting
   def perform(id)
     @id = id
-
     work = object
+    user = User.find_by_user_key(work.depositor)
 
     # Don't mint a handle if already has one
-    return if work.hdl
-  end
+    return if work.doi
 
-  private
+    if DoiMintingService.mint_doi_for work
+      # do success callback
+      if CurationConcerns.config.callback.set?(:after_doi_success)
+        CurationConcerns.config.callback.run(:after_doi_success, work, user, log.created_at)
+      end
+    else
+      # do failure callback
+      if CurationConcerns.config.callback.set?(:after_doi_failure)
+        CurationConcerns.config.callback.run(:after_doi_failure, work, user, log.created_at)
+      end
+    end
+  end
 end

--- a/app/models/concerns/umrdr/generic_work_metadata.rb
+++ b/app/models/concerns/umrdr/generic_work_metadata.rb
@@ -4,8 +4,8 @@ module Umrdr
     extend ActiveSupport::Concern
     included do
       property :subject, predicate: ::RDF::Vocab::MODS.subject
-      property :doi, predicate: ::RDF::Vocab::Identifiers.doi
-      property :hdl, predicate: ::RDF::Vocab::Identifiers.hdl
+      property :doi, predicate: ::RDF::Vocab::Identifiers.doi, multiple: false
+      property :hdl, predicate: ::RDF::Vocab::Identifiers.hdl, multiple: false
     end
   end
 end

--- a/app/services/umrdr/doi_minting_service.rb
+++ b/app/services/umrdr/doi_minting_service.rb
@@ -1,0 +1,44 @@
+module Umrdr
+  class DoiMintingService
+    attr :work
+
+    def self.mint_doi_for(work)
+      Umrdr::DoiMintingService.new(work).run
+    end
+
+    def initialize(work)
+      @work = work
+    end
+
+    def run
+      return unless doi_server_reachable?
+      work.doi = mint_doi
+      work.save
+      work.doi
+    end
+
+    private
+
+    # Check that the server is reachable
+    def doi_server_reachable?
+      # Invoke the API and get response
+      true
+    end
+
+    def generate_metadata
+      Ezid::Metadata.new.tap do |md|
+        md.datacite_title = work.title.first
+        md.datacite_publisher = "University of Michigan"
+        md.datacite_publicationyear = Date.today.year.to_s
+        md.datacite_resource_type="Dataset"
+        md.datacite_creator=work.creator.join(',')
+        md.target = Rails.application.routes.url_helpers.curation_concerns_generic_work_url(id: work.id)
+      end
+    end
+
+    def mint_doi
+      identifier = Ezid::Identifier.create(metadata: generate_metadata)
+      identifier.id
+    end
+  end
+end

--- a/app/services/umrdr/handle_minting_service.rb
+++ b/app/services/umrdr/handle_minting_service.rb
@@ -1,27 +1,33 @@
 module Umrdr
   class HandleMintingService
+    attr work, hdl_prefix
 
-    def self.mint_handle_for(work)
-      do_the_thing_for work
+    def self.mint_handle_for(work, hdl_prefix=nil)
+      srvc = HandleMintingService.new work, hdl_prefix
+      srvc.run
+    end
+
+    def initialize(work, prefix)
+      @work = work
+      @prefix = prefix
     end
 
     private
 
+    def run
+      return unless handle_server_reachable?
+      mint_hdl
+    end
+
     # Check that the server is reachable
     def handle_server_reachable?
       # Invoke the API and get response
-
+      false
     end
 
-    def do_the_thing_for(work)
-      return unless handle_server_reachable?
-      new_hdl = hdl_for work
-    end
-
-    def hld_for(work, hdl_prefix=nil)
+    def mint_hdl
       # Do something with the work id and handle prefix
-
+      1000000
     end
-
   end
 end

--- a/bin/setup
+++ b/bin/setup
@@ -16,7 +16,9 @@ Dir.chdir APP_ROOT do
   puts "\n== Copying sample files =="
   config_file_targets = [ "config/database.yml", "config/secrets.yml", "config/blacklight.yml",
                           "config/fedora.yml", "config/solr.yml", "config/redis.yml",
-                          "config/resque-pool.yml", "config/jetty.yml"]
+                          "config/resque-pool.yml", "config/jetty.yml", "config/ezid.yml",
+                          "config/browse_everything_providers.yml"]
+
   config_file_targets.each do |t|
     src = "#{t}.sample"
     unless File.exist?(t)

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -4,3 +4,6 @@ require File.expand_path('../application', __FILE__)
 # Initialize the Rails application.
 Rails.application.initialize!
 
+# Set the default host for resolving _url methods
+Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -7,6 +7,9 @@ Rails.application.configure do
   # Redirect to cosign
   config.login_url = 'https://weblogin.umich.edu/?cosign-umrdr-stable.quod.lib.umich.edu&https://umrdr-stable.quod.lib.umich.edu/data/dashboard'
 
+  # Set the default host for resolving _url methods
+  Rails.application.routes.default_url_options[:host] = 'deepblue.lib.umich.edu'
+
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.

--- a/config/ezid.yml.sample
+++ b/config/ezid.yml.sample
@@ -1,0 +1,14 @@
+development:
+  host: 'ezid.lib.purdue.edu'
+  port: 443
+  shoulder: 'doi:10.5072/FK2'
+  use_ssl: true
+  user: "eziduser"
+  password: "ezidpass"
+test:
+  host: 'ezid.lib.purdue.edu'
+  port: 443
+  shoulder: 'doi:10.5072/FK2'
+  use_ssl: true
+  user: "eziduser"
+  password: "ezidpass"

--- a/config/initializers/ezid.rb
+++ b/config/initializers/ezid.rb
@@ -1,0 +1,41 @@
+require 'erb'
+require 'yaml'
+
+# Yeah, there's many better ways to do this, but later.
+def load_yml
+  cfg_file="#{::Rails.root}/config/ezid.yml"
+
+  begin
+    ezid_erb = ERB.new(IO.read(cfg_file)).result(binding)
+  rescue StandardError, SyntaxError => e
+    raise("#{cfg_file} could not be parsed with ERB. \n#{e.inspect}")
+  end
+
+  begin
+    ezid_yml = YAML::load(ezid_erb)
+  rescue => e
+    raise("#{cfg_file} was found, but could not be parsed.\n#{e.inspect}")
+  end
+
+  if ezid_yml.nil? || !ezid_yml.is_a?(Hash)
+    raise("#{cfg_file} was found, but was blank or malformed.\n")
+  end
+
+  begin
+    raise "The #{::Rails.env} environment settings were not found in #{cfg_file}" unless ezid_yml[::Rails.env]
+    ezid_cfg = ezid_yml[::Rails.env].symbolize_keys
+  end
+
+  ezid_cfg
+end
+
+Ezid::Client.configure do |config|
+  yml_cfg = load_yml
+  config.host = yml_cfg[:host] || "localhost"
+  config.port = yml_cfg[:port] || 8443
+  config.use_ssl  = yml_cfg[:use_ssl] || true
+  config.user     = yml_cfg[:user] || "eziduser"
+  config.password = yml_cfg[:password] || "ezidpass"
+  config.default_shoulder = yml_cfg[:shoulder] || "ark:/99999/fk4"
+end
+

--- a/spec/services/doi_minting_service_spec.rb
+++ b/spec/services/doi_minting_service_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Umrdr::DoiMintingService do
+  let(:work) {GenericWork.new(id: '123', title: ['demotitle'], 
+                              creator: ['person1','person2','person3'])}
+  before do
+    allow(work).to receive(:save)
+  end
+
+  it "mints a doi" do
+    skip if ENV['TRAVIS']
+    expect(described_class.mint_doi_for(work)).to start_with 'doi:10.5072/FK2' 
+  end
+end


### PR DESCRIPTION

Add ezid-client dependency.
Add ezid config
Add host for default_url_options in dev|test|prod.
  This allows _url calls to fill in the host if not specified.
Make doi and hdl metadata properties singular.
Add DOI minting service and spec
Add DOI job with unimplemented callbacks.