### PR TITLE
Display upload confirmation after user attaches files to work

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,3 +17,4 @@
 
 //= require sufia
 //= require manage_repeating_fields
+//= require uploader.js

--- a/app/assets/javascripts/uploader.js
+++ b/app/assets/javascripts/uploader.js
@@ -1,0 +1,182 @@
+//= require fileupload/tmpl
+//= require fileupload/jquery.iframe-transport
+//= require fileupload/jquery.fileupload.js
+//= require fileupload/jquery.fileupload-ui.js
+//= require fileupload/locale.js
+//
+/*jslint nomen: true */
+/*global $ */
+
+
+//2 GB  max file size 
+var max_file_size = 2 * Math.pow(1024, 3);
+var max_file_size_str = "2 GB";
+//500 MB max total upload size
+var max_total_file_size = max_file_size * 5;
+var max_file_count = 100;
+var max_total_file_size_str = "10 GB";
+var first_file_after_max = ''; 
+var filestoupload =0;
+
+(function( $ ){
+  'use strict';
+
+  $.fn.sufiaUploader = function( options ) {  
+
+    // Create some defaults, extending them with any options that were provided
+    // option afterSubmit: function(form, event, data)
+    var settings = $.extend( { }, options);
+    var files_done =0;    
+    var timestamp = Date.now();  
+    var error_string ='';
+    $("#fail").hide();
+    $("#partial_fail").hide();
+    $("#errmsg").hide();
+
+    function uploadStopped() {
+      if (files_done == filestoupload && (files_done >0)){
+         var loc = $.trim($("#redirect-loc").text());
+         if ( loc.indexOf('?') > -1 ) {
+           loc += '&';
+         } else {
+           loc += '?';
+         }
+         loc += 'uploads_since=' + timestamp;
+         $(location).attr('href',loc);
+      } else if (error_string.length > 0){
+        // an error occured       
+         if (files_done == 0) {
+            $("#fail").show()
+         } else {
+            $("#partial_fail").show()
+         }          
+         $("#errmsg").html(error_string);
+         $("#errmsg").show();
+      }
+    } 
+
+    function uploadAdd(e, data) {
+      filestoupload++;
+      if ( $('#terms_of_service').is(':checked') )
+        $('#main_upload_start').attr('disabled', false);
+    }
+
+    function uploadAdded(e, data) {
+      if (data.files[0].error == 'acceptFileTypes'){
+        $($('#fileupload .files .cancel button')[data.context[0].rowIndex]).click(); 
+      }
+      var total_sz = parseInt($('#total_upload_size').val()) + data.files[0].size;
+      // is file size too big
+      if (data.files[0].size > max_file_size) {
+        $($('#fileupload .files .cancel button')[data.context[0].rowIndex]).click(); 
+        $("#errmsg").html(data.files[0].name + " is too big. No files over " + max_file_size_str + " can be uploaded.");
+        $("#errmsg").fadeIn('slow');
+      }
+      // cumulative upload file size is too big
+      else if( total_sz > max_total_file_size) {
+        if (first_file_after_max == '') first_file_after_max = data.files[0].name;
+        $($('#fileupload .files .cancel button')[data.context[0].rowIndex]).click(); 
+        $("#errmsg").html("All files selected from " + first_file_after_max + " and after will not be uploaded because your total upload is too big. You may not upload more than " + max_total_file_size_str + " in one upload.");
+        $("#errmsg").fadeIn('slow');
+      }
+      else if( filestoupload > max_file_count) {
+        if (first_file_after_max == '') first_file_after_max = data.files[0].name;
+        $($('#fileupload .files .cancel button')[data.context[0].rowIndex]).click(); 
+        $("#errmsg").html("All files selected from " + first_file_after_max + " and after will not be uploaded because your total number of files is too big. You may not upload more than " + max_file_count + " files in one upload.");
+        $("#errmsg").fadeIn('slow');
+      }
+      else {
+        $('#total_upload_size').val( parseInt($('#total_upload_size').val()) + data.files[0].size );
+      }
+    }
+
+
+    function uploadDone(e, data) {
+      var file = ($.isArray(data.result) && data.result[0]) || {error: 'emptyResult'};
+      if (!file.error) {
+        files_done++;     
+      } else {
+        if (error_string.length > 0) {
+          error_string += '<br/>';
+        }
+        error_string += file.error;
+      }
+    }
+
+    // Takes the contextual values in the file you're uploading
+    // and assign them to a value in the form that is being uploaded:
+    // based off of https://github.com/blueimp/jQuery-File-Upload/wiki/How-to-submit-additional-Form-Data
+    function uploadSubmit(e, data) {
+      $('#relative_path').val(data.files[0].webkitRelativePath)
+      if (settings.afterSubmit) {
+        settings.afterSubmit(this, e, data)
+      }
+    }
+
+    function uploadFail(e, data) {
+      if (data.errorThrown == 'abort') {
+         filestoupload--;
+         if ((files_done == filestoupload)&&(files_done >0)){
+             var loc = $("#redirect-loc").html()+"?file_count="+filestoupload
+             $(location).attr('href',loc);
+         }
+         $('#total_upload_size').val( parseInt($('#total_upload_size').val()) - data.files[0].size );
+         
+      } else {
+       if (error_string.length > 0) {
+          error_string += '<br/>';
+       }
+       error_string += data.errorThrown + ": " + data.textStatus;
+      }
+    }
+
+    var $container = this;
+    return this.each(function() {        
+      // Initialize the jQuery File Upload widget:
+      $(this).fileupload();
+
+      // Enable iframe cross-domain access via redirect option:
+      $('#fileupload').fileupload(
+          'option',
+          'redirect',
+          window.location.href.replace(
+              /\/[^\/]*$/,
+              '/cors/result.html?%s'
+          )
+      );
+
+      $('#fileupload').fileupload(
+          'option',
+          'acceptFileTypes',
+          /^[^\.].*$/i
+      );
+
+      // ONLY EFFECTS BROWSERS SUPPORTING FILE API (IE>=10)
+      $('#fileupload').fileupload(
+          'option',
+          'maxFileSize',
+          max_file_size
+      );
+
+      $('#fileupload').bind("fileuploadstop", uploadStopped);
+
+      // count the number of uploaded files to send to edit
+      $('#fileupload').bind("fileuploadadd", uploadAdd);
+      
+      
+      // check the validation on if the file type is not accepted just click cancel for the user as we do not want them to see all the hidden files
+      $('#fileupload').bind("fileuploadadded", uploadAdded);
+
+      // count the number of files completed and ready to send to edit                          
+      $('#fileupload').bind("fileuploaddone", uploadDone);
+
+      $('#fileupload').bind('fileuploadsubmit', uploadSubmit);
+
+
+      // on fail if abort (aka cancel) decrease the number of uploaded files to send
+      $('#fileupload').bind("fileuploadfail", uploadFail);
+
+    });
+
+  };
+})( jQuery );  

--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate curation_concerns:work GenericWork`
 
-require 'pp'
 class CurationConcerns::GenericWorksController < ApplicationController
   include CurationConcerns::CurationConcernController
   # Adds Sufia behaviors to the controller.
@@ -12,15 +11,32 @@ class CurationConcerns::GenericWorksController < ApplicationController
   set_curation_concern_type GenericWork
 
   def check_recent_uploads
-    if params[:since]
+    if params[:uploads_since]
       begin
-        since = params[:since].to_i
-        presenter.file_presenters.each do |what|
-          pp(what, STDERR)
+        @recent_uploads = [];
+        uploads_since = Time.at(params[:uploads_since].to_i / 1000.0)
+        presenter.file_presenters.reverse_each do |file_set|
+          date_uploaded = get_date_uploaded_from_solr(file_set)
+          if date_uploaded.nil? or date_uploaded < uploads_since
+            break
+          end
+          @recent_uploads.unshift file_set
         end
-      rescue
+      rescue Exception => e
+        Rails.logger.info "Something happened in check_recent_uploads: #{params[:uploads_since]} : #{e.message}"
       end
     end
   end
+
+  private
+    def get_date_uploaded_from_solr(file_set)
+      field = file_set.solr_document[Solrizer.solr_name('date_uploaded', :stored_sortable, type: :date)]
+      return unless field.present?
+      begin
+        Time.parse(field)
+      rescue
+        Rails.logger.info "Unable to parse date: #{field.first.inspect} for #{self['id']}"
+      end
+    end
 
 end

--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -1,10 +1,26 @@
 # Generated via
 #  `rails generate curation_concerns:work GenericWork`
 
+require 'pp'
 class CurationConcerns::GenericWorksController < ApplicationController
   include CurationConcerns::CurationConcernController
   # Adds Sufia behaviors to the controller.
   include Sufia::WorksControllerBehavior
 
+  before_action :check_recent_uploads, only: [:show]
+
   set_curation_concern_type GenericWork
+
+  def check_recent_uploads
+    if params[:since]
+      begin
+        since = params[:since].to_i
+        presenter.file_presenters.each do |what|
+          pp(what, STDERR)
+        end
+      rescue
+      end
+    end
+  end
+
 end

--- a/app/views/curation_concerns/base/_recent_uploads.html.erb
+++ b/app/views/curation_concerns/base/_recent_uploads.html.erb
@@ -1,0 +1,16 @@
+<% unless @recent_uploads.blank? %>
+<div class="alert alert-block alert-success">
+    <a class="close" data-dismiss="alert" href="#">&times;</a>
+    <p>
+        <%= t('generic_work.upload_success') %>
+    </p>
+    <p>
+        Uploaded files:
+    </p>
+    <ul>
+        <% @recent_uploads.each do |file_set| %>
+            <li><a href="#f<%= file_set.id %>"><%= file_set.link_name %></a></li>
+        <% end %>
+    </ul>
+</div>
+<% end %>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -6,6 +6,7 @@
 <% collector = can?(:collect, @presenter.id) %>
 <% editor    = can?(:edit,    @presenter.id) %>
 
+<%= render 'recent_uploads', work: @presenter %>
 <%= render 'representative_media', work: @presenter %>
 <%= render 'attributes', curation_concern: @presenter %>
 <%= render 'related_files', presenter: @presenter %>

--- a/app/views/curation_concerns/file_sets/_file_set.html.erb
+++ b/app/views/curation_concerns/file_sets/_file_set.html.erb
@@ -1,0 +1,12 @@
+<tr class="<%= dom_class(file_set) %> attributes" id="f<%= file_set.id %>">
+  <td class="thumbnail">
+    <%= render_thumbnail_tag file_set %>
+  </td>
+  <td class="attribute filename"><%= link_to(file_set.link_name, main_app.curation_concerns_file_set_path(file_set)) %></td>
+  <td class="attribute date_uploaded"><%= file_set.date_uploaded %></td>
+  <td class="attribute permission"><%= file_set.permission_badge %></td>
+  <td>
+    <%= render 'curation_concerns/file_sets/actions', file_set: file_set %>
+  </td>
+</tr>
+

--- a/config/locales/umrdr.en.yml
+++ b/config/locales/umrdr.en.yml
@@ -5,6 +5,9 @@ en:
   homepage:
     marketing_blurb: 'Deep Blue Data is a repository offered by the University of Michigan Library that provides access and preservation services for digital research data that were developed or used in the support of research activities at U-M.'
 
+  generic_work:
+    upload_success: 'Great work! Your upload was successful.'
+
   simple_form:
     required:
       html: '<span class="required required-tag">required</span>'


### PR DESCRIPTION
In support of #110.

- modifies uploader.js to 
  - define max file sizes to UMRDR sizes
  - set up the upload plugin to be file size aware
  - attach "uploaded_since" parameter to the redirect
- generic_works_controller uses uploaded_since to gather a list of the files uploaded since then
- viewing the generic work will present a confirmation alert if that list is non-empty