### PR TITLE
Add rights property validation to GenericWork.

### DIFF
--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -8,6 +8,7 @@ class GenericWork < ActiveFedora::Base
   validates :creator, presence: { message: 'Your work must have a creator.' }
   validates :date_created, presence: { message: 'Your work must have a date created.' }
   validates :description, presence: { message: 'Your work must have a description.' }
+  validates :rights, presence: { message: 'You must select a license for your work.' }
 
   after_initialize :set_defaults
 

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -35,25 +35,31 @@ describe GenericWork do
       subject.creator = ['Demo Creator']
       subject.date_created = ['2016-02-28']
       subject.description = ['Demo description.']
+      subject.rights = ['Demo rights.']
     end
 
     it 'validates title' do
-      subject.title = nil
+      subject.title = []
       expect(subject).not_to be_valid
     end
 
     it 'validates date_created' do
-      subject.date_created = nil
+      subject.date_created = []
       expect(subject).not_to be_valid
     end
 
     it 'validates description' do
-      subject.description = nil
+      subject.description = []
       expect(subject).not_to be_valid
     end
 
     it 'validates creator' do
-      subject.creator = nil
+      subject.creator = []
+      expect(subject).not_to be_valid
+    end
+
+    it 'validates rights' do
+      subject.rights = []
       expect(subject).not_to be_valid
     end
   end


### PR DESCRIPTION
Closes #123 by requiring a license in the model validation.