### PR TITLE
Cosign authentication fixes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,8 @@ class SessionsController < ApplicationController
   def destroy
     # make any local additions here (e.g. expiring local sessions, etc.)
     # adapted from here: http://cosign.git.sourceforge.net/git/gitweb.cgi?p=cosign/cosign;a=blob;f=scripts/logout/logout.php;h=3779248c754001bfa4ea8e1224028be2b978f3ec;hb=HEAD
-    cookies.delete(request.env['COSIGN_SERVICE']) if request.env['COSIGN_SERVICE']
+    sign_out(:user)
+    cookies.delete(Sufia::Engine.config.cosign_service)
     redirect_to Sufia::Engine.config.logout_url
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,9 +16,14 @@ module Umrdr
     # Deploy to /data instead of /
     config.relative_url_root = '/data'
 
-    # Redirect to cosign
-    config.login_url = 'https://weblogin.umich.edu/?cosign-umrdr-testing.quod.lib.umich.edu&https://umrdr-testing.quod.lib.umich.edu/data/dashboard'
-    config.logout_url = 'https://weblogin.umich.edu/cgi-bin/logout?https://umrdr-testing.quod.lib.umich.edu/data'
+    # Cosign configuration
+    config.hostname = 'umrdr-testing.quod.lib.umich.edu'
+    config.cosign_host = 'weblogin.umich.edu'
+    config.cosign_service = "cosign-#{config.hostname}"
+    config.cosign_login_redirect = "https://#{config.hostname}/data/dashboard"
+    config.cosign_logout_redirect = "https://#{config.hostname}/data"
+    config.login_url = "https://#{config.cosign_host}/?#{config.cosign_service}&#{config.cosign_login_redirect}"
+    config.logout_url = "https://#{config.cosign_host}/cgi-bin/logout?#{config.cosign_logout_redirect}"
     
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,11 +4,11 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
-  # Redirect to cosign
-  config.login_url = 'https://weblogin.umich.edu/?cosign-umrdr-stable.quod.lib.umich.edu&https://umrdr-stable.quod.lib.umich.edu/data/dashboard'
+  # For Cosign redirection
+  config.hostname = 'deepblue.lib.umich.edu'
 
   # Set the default host for resolving _url methods
-  Rails.application.routes.default_url_options[:host] = 'deepblue.lib.umich.edu'
+  Rails.application.routes.default_url_options[:host] = config.hostname
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers

--- a/lib/devise/behaviors/http_header_authenticatable_behavior.rb
+++ b/lib/devise/behaviors/http_header_authenticatable_behavior.rb
@@ -4,7 +4,8 @@ module Behaviors
 
     # Called if the user doesn't already have a rails session cookie
     def valid_user?(headers)
-      !remote_user(headers).blank?
+      remote_user = remote_user(headers)
+      !remote_user.blank? and remote_user != '(null)'
     end
 
     protected


### PR DESCRIPTION
 - Don't show user as '(null)' if X-Remote-User header is empty
 - Properly delete Cosign service cookie & destroy user session on logout
 - DRY up Cosign configuration