### PR TITLE
add and support methodology property in GenericWork

### DIFF
--- a/app/forms/curation_concerns/forms/work_form.rb
+++ b/app/forms/curation_concerns/forms/work_form.rb
@@ -8,7 +8,7 @@ module CurationConcerns
                :open_access_with_embargo_release_date?, :private_access?,
                :embargo_release_date, :lease_expiration_date, :member_ids, to: :model
 
-      self.terms = [:title, :creator, :contributor, :description,
+      self.terms = [:title, :creator, :contributor, :methodology, :description,
                     :tag, :rights, :publisher, :date_created, :subject, :language,
                     :identifier, :based_near, :related_url,
                     :representative_id, :thumbnail_id, :files,

--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -5,10 +5,10 @@ module CurationConcerns
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
     self.terms += [:resource_type]
-    self.required_fields = [ :title, :creator, :date_created, :description, :rights ]
+    self.required_fields = [ :title, :creator, :date_created, :methodology, :description, :rights ]
 
     def rendered_terms
-      [ :title, :creator, :contributor, :description, :date_created, :rights, :subject, :tag, :language, :identifier, :resource_type ]
+      [ :title, :creator, :contributor, :methodology, :description, :date_created, :rights, :subject, :tag, :language, :identifier, :resource_type ]
     end
 
   end

--- a/app/models/concerns/umrdr/generic_work_metadata.rb
+++ b/app/models/concerns/umrdr/generic_work_metadata.rb
@@ -6,6 +6,10 @@ module Umrdr
       property :subject, predicate: ::RDF::Vocab::MODS.subject
       property :doi, predicate: ::RDF::Vocab::Identifiers.doi, multiple: false
       property :hdl, predicate: ::RDF::Vocab::Identifiers.hdl, multiple: false
+      property :methodology, predicate: ::RDF::URI.new('http://www.ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/FieldLevelDocumentation/schemas/datacollection_xsd/elements/DataCollectionMethodology.html'), multiple: false do |index|
+        index.type :text
+        index.as :stored_searchable
+      end
     end
   end
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -8,6 +8,7 @@ class GenericWork < ActiveFedora::Base
   validates :creator, presence: { message: 'Your work must have a creator.' }
   validates :date_created, presence: { message: 'Your work must have a date created.' }
   validates :description, presence: { message: 'Your work must have a description.' }
+  validates :methodology, presence: { message: 'Your work must have a description of the method for collecting the dataset.' }
   validates :rights, presence: { message: 'You must select a license for your work.' }
 
   after_initialize :set_defaults

--- a/app/views/records/edit_fields/_methodology.html.erb
+++ b/app/views/records/edit_fields/_methodology.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.class.multiple? key %>
+  <%= f.input :methodology, as: :multi_value_with_accessible_help, input_html: { rows: '14', type: 'textarea'}, required: true, force_single: true %>
+<% else %>
+  <%= f.input :methodology, as: :text, input_html: { rows: '14' } %>
+<% end %>

--- a/config/locales/umrdr.en.yml
+++ b/config/locales/umrdr.en.yml
@@ -50,6 +50,9 @@ en:
         tag:
           'The topic of the resource.'
 
+        methodology:
+          'The way the dataset was collected (equipment used for sensing, survey methodology, etc.).'
+
     labels:
       generic_work:
         rights: "Creative Commons License"
@@ -61,6 +64,8 @@ en:
         subject: "Discipline"
 
         date_created: "Date Created"
+
+        methodology: "Method"
 
     add_remove_labels:
       generic_work:


### PR DESCRIPTION
Supports #141.

Add and support methodology property in GenericWork.

`methodology` is single-valued, stored, and indexed.

After doi_service branch is merged, the umrdr work presenter can delete `methodology` to the solr doc and we can add `methodology` to the attributes shown (if desired).