### PR TITLE
remove duplicate name entry on user profile

### DIFF
--- a/app/views/dashboard/_index_partials/_user_info.html.erb
+++ b/app/views/dashboard/_index_partials/_user_info.html.erb
@@ -4,11 +4,7 @@
   </div>
   <div class="panel-body">
     <div class="col-xs-12 user-info">
-      <h3><%= @user.name %></h3>
-      <h4><%= @user.title %></h4>
-      <h4><%= @user.department %></h4>
-      <h5><%= link_to_telephone %></h5>
-      <h5><%= @user.email %></h5>
+      <h3><%= @user.email %></h3>
     </div>
 
     <div class="col-xs-6 col-sm-12 col-md-6 user-info">


### PR DESCRIPTION
Currently, the user cannot edit display name, phone number, title and department. 

TODO later: Add edit display name and other required fields on edit user page