### PR TITLE
repairs to backlight configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :development do
   gem 'web-console', '~> 2.0'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'ffaker'
 end
 
 # Specific commits of gems.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     fcrepo_wrapper (0.2.1)
       ruby-progressbar
+    ffaker (2.2.0)
     ffi (1.9.10)
     font-awesome-rails (4.5.0.1)
       railties (>= 3.2, < 5.1)
@@ -735,6 +736,7 @@ DEPENDENCIES
   engine_cart
   ezid-client
   fcrepo_wrapper (~> 0.1)
+  ffaker
   jbuilder (~> 2.0)
   jquery-rails
   kaminari!

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -20,6 +20,10 @@ class CatalogController < ApplicationController
     false
   end
 
+  def search_builder_class
+    Umrdr::CatalogSearchBuilder
+  end
+
   configure_blacklight do |config|
 
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
@@ -31,7 +35,7 @@ class CatalogController < ApplicationController
     config.advanced_search[:query_parser] ||= 'dismax'
     config.advanced_search[:form_solr_parameters] ||= {}
 
-    config.search_builder_class = Sufia::SearchBuilder
+    config.search_builder_class = Umrdr::SearchBuilder
 
     # Show gallery view
     # config.view.gallery.partials = [:index_header, :index]
@@ -139,7 +143,7 @@ class CatalogController < ApplicationController
     # subject, language, resource_type, format, identifier, based_near,
     config.add_search_field('contributor') do |field|
       # solr_parameters hash are sent to Solr as ordinary url query params.
-      field.solr_parameters = { :"spellcheck.dictionary" => "contributor" }
+      ## field.solr_parameters = { :"spellcheck.dictionary" => "contributor" }
 
       # :solr_local_parameters will be sent using Solr LocalParams
       # syntax, as eg {! qf=$title_qf }. This is neccesary to use
@@ -153,7 +157,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('creator') do |field|
-      field.solr_parameters = { :"spellcheck.dictionary" => "creator" }
+      ## field.solr_parameters = { :"spellcheck.dictionary" => "creator" }
       solr_name = solr_name("creator", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
@@ -162,9 +166,9 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('title') do |field|
-      field.solr_parameters = {
-        :"spellcheck.dictionary" => "title"
-      }
+      # field.solr_parameters = {
+      #   :"spellcheck.dictionary" => "title"
+      # }
       solr_name = solr_name("title", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
@@ -174,9 +178,9 @@ class CatalogController < ApplicationController
 
     config.add_search_field('description') do |field|
       field.label = "Abstract or Summary"
-      field.solr_parameters = {
-        :"spellcheck.dictionary" => "description"
-      }
+      # field.solr_parameters = {
+      #   :"spellcheck.dictionary" => "description"
+      # }
       solr_name = solr_name("description", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
@@ -185,9 +189,9 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('publisher') do |field|
-      field.solr_parameters = {
-        :"spellcheck.dictionary" => "publisher"
-      }
+      # field.solr_parameters = {
+      #   :"spellcheck.dictionary" => "publisher"
+      # }
       solr_name = solr_name("publisher", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
@@ -196,9 +200,9 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('date_created') do |field|
-      field.solr_parameters = {
-        :"spellcheck.dictionary" => "date_created"
-      }
+      # field.solr_parameters = {
+      #   :"spellcheck.dictionary" => "date_created"
+      # }
       solr_name = solr_name("created", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
@@ -218,9 +222,9 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('language') do |field|
-      field.solr_parameters = {
-        :"spellcheck.dictionary" => "language"
-      }
+      # field.solr_parameters = {
+      #   :"spellcheck.dictionary" => "language"
+      # }
       solr_name = solr_name("language", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
@@ -229,9 +233,9 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('resource_type') do |field|
-      field.solr_parameters = {
-        :"spellcheck.dictionary" => "resource_type"
-      }
+      # field.solr_parameters = {
+      #   :"spellcheck.dictionary" => "resource_type"
+      # }
       solr_name = solr_name("resource_type", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
@@ -241,9 +245,9 @@ class CatalogController < ApplicationController
 
     config.add_search_field('format') do |field|
       field.include_in_advanced_search = false
-      field.solr_parameters = {
-        :"spellcheck.dictionary" => "format"
-      }
+      # field.solr_parameters = {
+      #   :"spellcheck.dictionary" => "format"
+      # }
       solr_name = solr_name("format", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
@@ -253,9 +257,9 @@ class CatalogController < ApplicationController
 
     config.add_search_field('identifier') do |field|
       field.include_in_advanced_search = false
-      field.solr_parameters = {
-        :"spellcheck.dictionary" => "identifier"
-      }
+      # field.solr_parameters = {
+      #   :"spellcheck.dictionary" => "identifier"
+      # }
       solr_name = solr_name("id", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
@@ -265,9 +269,9 @@ class CatalogController < ApplicationController
 
     config.add_search_field('based_near') do |field|
       field.label = "Location"
-      field.solr_parameters = {
-        :"spellcheck.dictionary" => "based_near"
-      }
+      # field.solr_parameters = {
+      #   :"spellcheck.dictionary" => "based_near"
+      # }
       solr_name = solr_name("based_near", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
@@ -276,9 +280,9 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('tag') do |field|
-      field.solr_parameters = {
-        :"spellcheck.dictionary" => "tag"
-      }
+      # field.solr_parameters = {
+      #   :"spellcheck.dictionary" => "tag"
+      # }
       solr_name = solr_name("tag", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,

--- a/app/helpers/sufia_helper.rb
+++ b/app/helpers/sufia_helper.rb
@@ -20,4 +20,11 @@ module SufiaHelper
     link_to text, "/data/users/#{login}"
   end
 
+  def link_to_field(fieldname, fieldvalue, displayvalue = nil)
+    p = { search_field: fieldname, q: '"' + fieldvalue + '"' }
+    link_url = main_app.search_catalog_path(p)
+    display = displayvalue.blank? ? fieldvalue : displayvalue
+    link_to(display, link_url)
+  end
+
 end

--- a/app/search_builders/umrdr/catalog_search_builder.rb
+++ b/app/search_builders/umrdr/catalog_search_builder.rb
@@ -1,0 +1,10 @@
+class Umrdr::CatalogSearchBuilder < Umrdr::SearchBuilder
+  # TODO: verify there's no remaining "advanced" search links that 
+  # require :add_advanced_sarch_to_solr
+  self.default_processor_chain += [
+    :add_access_controls_to_solr_params,
+    :add_advanced_parse_q_to_solr,
+    # :add_advanced_search_to_solr,
+    :show_works_or_works_that_contain_files
+  ]
+end

--- a/app/search_builders/umrdr/search_builder.rb
+++ b/app/search_builders/umrdr/search_builder.rb
@@ -1,0 +1,26 @@
+class Umrdr::SearchBuilder < Sufia::SearchBuilder
+
+  # show both works that match the query and works that contain files that match the query
+  def show_works_or_works_that_contain_files(solr_parameters)
+    return if solr_parameters[:q].blank?
+    extract_user_params(solr_parameters[:q])
+    solr_parameters[:user_query] = extract_user_query(solr_parameters[:q])
+    solr_parameters[:q] = new_query
+  end
+
+  protected
+
+    def extract_user_params(query)
+      @user_params = query.split('}')[0].split('{')[1].sub('!', '').sub('dismax ', '')
+    end
+
+    def extract_user_query(query)
+      query.split('}')[1]
+    end
+
+    # the {!dismax} causes the query to go against the query fields
+    def dismax_query
+      ## "{!dismax v=$user_query}"
+      "{!dismax #{@user_params} v=$user_query}"
+    end
+end

--- a/lib/tasks/populate_fake_data.rake
+++ b/lib/tasks/populate_fake_data.rake
@@ -1,0 +1,45 @@
+require 'yaml'
+
+require 'ffaker'
+
+namespace :umrdr do
+
+  desc "Populate app with much fake data."
+  task :populate_fake_data, [:path_to_config] => :environment do |t, args|
+    ENV["RAILS_ENV"] ||= "development"
+
+    fake_setup
+
+    puts "Done."
+  end
+end
+
+def fake_setup
+  users = User.all.to_a
+  num_users = ( ENV['NUM_USERS'] || '10' ).to_i
+  num_users -= users.length
+  (0..num_users).each do |idx|
+    email = FFaker::Internet.email
+    user = User.find_by( email: email ) || create_user( email )
+    users << user
+  end
+  num_works = ( ENV['NUM_WORKS'] || '100' ).to_i
+  (0..num_works).each do |idx|
+    user = users[rand(users.length)]
+    work = GenericWork.new(
+      title: [FFaker::Movie.title],
+      owner: user.user_key,
+      creator: [user.user_key],
+      description: [FFaker::DizzleIpsum.paragraph],
+      methodology: FFaker::DizzleIpsum.paragraph,
+      rights: ['http://creativecommons.org/publicdomain/zero/1.0/'],
+      tag:FFaker::CheesyLingo.words,
+      date_created: [FFaker::Time.date],
+    )
+    work.apply_depositor_metadata(user.user_key)
+    work.save
+
+    STDERR.puts "-- installed #{work.title[0]} : #{user.user_key} : #{work.id}"
+  end
+end
+


### PR DESCRIPTION
Sufia wraps queries to match works that match the query *and* contain files that match. This custom SearchBuilder modifies the assembly.

The catalog configuration disables custom spellcheck dictionaries that don't exist in the solr config (queries are successful but then solr raises a nullpointer exception).

The rake task can be used to quickly populate a development database with users + works, handy for testing search. `NUM_USERS=10 NUM_WORKS=100 bundle exec rake umrdr:populate_fake_data`. 

(Adds the `ffaker` gem to development; requires `bundle install`)

