### PR TITLE
Build content service

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ActiveRecord::Base
 
   def generate_password
     self.password = SecureRandom.urlsafe_base64(12)
+    self.password_confirmation = self.password
   end
 
   # Use the http header as auth.  This app will be behind a reverse proxy

--- a/lib/build_content_service.rb
+++ b/lib/build_content_service.rb
@@ -75,17 +75,23 @@ class BuildContentService
     end
   end
 
+  def log_object(obj)
+    puts "id: #{obj.id} title: #{obj.title.first}"
+  end
+
   def build_repo_contents
-    user = User.find_by_user_key( user_key ) || create_user( user_key)
+    user = User.find_by_user_key(user_key) || create_user(user_key)
     if user.nil?
       puts "User not found."
       return
     end
 
     # build works
-    
-
-    works.each{|work_hsh| build_work(work_hsh)} if works
+    if works
+      works.each do |work_hash|
+        log_object(build_work(work_hash))
+      end
+    end
 
     # build collections
     collections.each{|coll_hsh| build_collection(coll_hsh)} if collections
@@ -93,7 +99,6 @@ class BuildContentService
 
   # build collection then call build_work
   def build_collection(c_hsh)
-
     title = c_hsh['title']
     desc  = c_hsh['desc']
     col = Collection.new(title: title, description: desc, creator: Array(user_key))
@@ -143,7 +148,7 @@ class BuildContentService
     Hydra::Works::CharacterizationService.run(fs)
     # Add title and filename
     fs.filename = filename if filename
-    fs.title = fs.filename
+    fs.title = Array(fs.filename)
     fs.save
     return fs
   end

--- a/lib/build_content_service.rb
+++ b/lib/build_content_service.rb
@@ -1,4 +1,5 @@
 require 'hydra/file_characterization'
+require 'pry'
 
 Hydra::FileCharacterization::Characterizers::Fits.tool_path = `which fits || which fits.sh`.strip
 
@@ -139,7 +140,9 @@ class BuildContentService
     return gw
   end
 
+  # If filename not given, use basename from path
   def build_file_set(path, filename=nil)
+    fname = filename || File.basename(path)
     file = File.open(path)
     fs = FileSet.new()
     fs.apply_depositor_metadata(user_key)
@@ -147,8 +150,10 @@ class BuildContentService
     Hydra::Works::UploadFileToFileSet.call(fs, file)
     Hydra::Works::CharacterizationService.run(fs)
     # Add title and filename
-    fs.filename = filename if filename
-    fs.title = Array(fs.filename)
+    fs.filename = fname
+    fs.title = Array(fname)
+    fs.label = fname
+    fs.date_uploaded = Date.today.strftime('%F')
     fs.save
     return fs
   end

--- a/lib/build_content_service.rb
+++ b/lib/build_content_service.rb
@@ -121,7 +121,10 @@ class BuildContentService
     date_created = Array(w_hsh[:date_created])   
     rtype = Array(w_hsh[:resource_type] || 'Dataset')
 
-    gw = GenericWork.new( title: title, creator: creator, rights: rights, description: desc, resource_type: rtype, methodology: methodology, subject: subject, contributor: contributor, date_created: date_created ) 
+    gw = GenericWork.new( title: title, creator: creator, rights: rights,
+                         description: desc, resource_type: rtype,
+                         methodology: methodology, subject: subject,
+                         contributor: contributor, date_created: date_created ) 
     paths_and_names = w_hsh[:files].zip w_hsh[:filenames]
     fsets = paths_and_names.map{|fp| build_file_set(fp[0], fp[1])}
     fsets.each{|fs| gw.ordered_members << fs}

--- a/lib/build_content_service.rb
+++ b/lib/build_content_service.rb
@@ -1,5 +1,4 @@
 require 'hydra/file_characterization'
-require 'pry'
 
 Hydra::FileCharacterization::Characterizers::Fits.tool_path = `which fits || which fits.sh`.strip
 

--- a/lib/devise/behaviors/http_header_authenticatable_behavior.rb
+++ b/lib/devise/behaviors/http_header_authenticatable_behavior.rb
@@ -3,9 +3,10 @@ module Behaviors
   module HttpHeaderAuthenticatableBehavior
 
     # Called if the user doesn't already have a rails session cookie
+    # Remote user needs to be present and not null
     def valid_user?(headers)
       remote_user = remote_user(headers)
-      !remote_user.present? and remote_user != '(null)'
+      remote_user.present? && remote_user != '(null)@umich.edu' 
     end
 
     protected


### PR DESCRIPTION
Updates to allow build content service to run.  User model needed to be updated to implicitly put in a random password AND password confirmation for created users.

The http auth behavior was updated to acommodate the change that appends the at domain.  So (null) became (null)@umich.edu which was not getting properly handled on the master branch.