### PR TITLE
Add CC descriptions to work edit page

### DIFF
--- a/app/forms/curation_concerns/forms/work_form.rb
+++ b/app/forms/curation_concerns/forms/work_form.rb
@@ -35,6 +35,10 @@ module CurationConcerns
         Hash[file_presenters.map { |file| [file.to_s, file.id] }]
       end
 
+      def rights
+        @model.rights.first
+      end
+
       class << self
         # This determines whether the allowed parameters are single or multiple.
         # By default it delegates to the model, but we need to override for

--- a/app/helpers/sufia_helper.rb
+++ b/app/helpers/sufia_helper.rb
@@ -27,4 +27,15 @@ module SufiaHelper
     link_to(display, link_url)
   end
 
+  def t_uri(key, scope: [])
+    new_scope = scope.collect do |arg|
+      if arg.is_a?(String)
+        arg.gsub('.', '_')
+      else
+        arg
+      end
+    end
+    I18n.t(key, scope: new_scope)
+  end
+
 end

--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -1,5 +1,14 @@
 <% options = RightsService.select_options.dup %>
-<%= f.input :rights,
-    collection: options,
-    include_blank: '- Choose Creative Commons License - ',
-    input_html: { class: 'form-control' } %>
+<div class="form-group radio_buttons generic_work_rights">
+    <%= f.label :rights %>
+    <%= f.collection_radio_buttons(:rights, options, :last, :first, item_wrapper_class: 'radio', item_wrapper_tag: :div, boolean_style: :inline) do |b|
+        ( content_tag :p do
+            b.label { b.radio_button + b.text }
+        end ) + 
+        ( content_tag :aside do
+            t_uri(:description, scope: [ :rights, b.value ])
+        end )
+    end %>
+    <%= f.hint :rights %>
+</div>
+ 

--- a/config/locales/umrdr.en.yml
+++ b/config/locales/umrdr.en.yml
@@ -96,3 +96,15 @@ en:
           subject_tesim: Discipline
         show:
           subject_tesim: Discipline
+
+  # urls-as-keys need to have their dots replaced with something else
+  rights:
+    http://creativecommons_org/publicdomain/zero/1_0/:
+      description:
+        "You dedicate this work to the public domain, waiving all your rights to the work worldwide under copyright law."
+    http://creativecommons_org/licenses/by/3_0/us/:
+      description:
+        "This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation."
+    http://creativecommons_org/licenses/by-nd/3_0/us/:
+      description:
+        "This license allows for redistribution, commercial and non-commercial, as long as it is passed along unchanged and in whole, with credit to you."

--- a/spec/forms/work_form_rights_spec.rb
+++ b/spec/forms/work_form_rights_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+describe CurationConcerns::Forms::WorkForm do
+  let(:rights) { RightsService.select_options[0][-1] }
+  let(:work) do
+    stub_model(GenericWork, id: '456', rights: [ rights ])
+  end
+  let(:ability) { nil }
+  let(:form) do
+    CurationConcerns::GenericWorkForm.new(work, ability)
+  end
+
+  it 'should return attribute as an array' do
+    expect(form['rights']).to eq [ rights ]
+  end
+
+  it 'should return rights as a single value' do
+    expect(form.rights).to eq rights
+  end
+end

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe SufiaHelper do
+  let(:rights) { RightsService.select_options[-1] }
+  let(:target) { I18n.t(:description, scope: [ :rights, rights[1].gsub('.', '_') ]) }
+  subject { helper.t_uri :description, scope: [ :rights, rights[1] ] }
+
+  it { is_expected.to eq target }
+
+end

--- a/spec/records/edit_fields/_rights.html.erb_spec.rb
+++ b/spec/records/edit_fields/_rights.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'records/edit_fields/_rights.html.erb', type: :view do
+
+  include SufiaHelper unless include?(SufiaHelper)
+
+  let(:work) do
+    stub_model(GenericWork, id: '456', rights: [ RightsService.select_options[0][-1] ])
+  end
+  let(:ability) { double }
+
+  let(:form) do
+    CurationConcerns::GenericWorkForm.new(work, ability)
+  end
+
+  let(:current_user) { sub_model(User) }
+
+  let(:f) do
+    SimpleForm::FormBuilder.new('generic-work', work, view, {})
+  end
+
+  before do
+    assign(:form, form)
+    render partial: "records/edit_fields/rights", locals: { f: f }
+  end
+
+  it "rights should have asides" do
+    num_asides = RightsService.select_options.length
+    expect(rendered).to have_selector(".generic_work_rights .radio aside", count: num_asides)
+  end
+
+  it "rights should have descriptions for each right" do
+    num_asides = RightsService.select_options.length
+    RightsService.select_options.each do |right|
+      expect(rendered).to have_content(t_uri(:description, scope: [ :rights, right[1] ]))
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes #226

Change rights presentation on form to offer brief inline descriptions of each license option.
For the radio form buttons to work, WorkForm had to be altered to pretend rights was single-valued. 
t_uri helper added to support keys-that-look-like-URLs out of the locale file.