### PR TITLE
Fix/248 validate license

### DIFF
--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -3,7 +3,7 @@
     <%= f.label :rights %>
     <%= f.collection_radio_buttons(:rights, options, :last, :first, item_wrapper_class: 'radio', item_wrapper_tag: :div, boolean_style: :inline) do |b|
         ( content_tag :p do
-            b.label { b.radio_button + b.text }
+            b.label { b.radio_button(required: true) + b.text }
         end ) + 
         ( content_tag :aside do
             t_uri(:description, scope: [ :rights, b.value ])
@@ -11,4 +11,4 @@
     end %>
     <%= f.hint :rights %>
 </div>
- 
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,6 +50,20 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
+
+  # DANGER: Turning off verify_partial_doubles allows mocking of any method.
+  # This is only being done for the specs under views. This allows the helpers
+  # for the view to be mocked, but also means tests could mock methods that 
+  # don't already exist on an object.
+  # Relevatn discussion at https://github.com/rspec/rspec-rails/issues/1076
+  config.around(:each, type: :view) do |ex|
+    config.mock_with :rspec do |mocks|
+      mocks.verify_partial_doubles = false
+      ex.run
+      mocks.verify_partial_doubles = true
+    end
+  end
+
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:

--- a/spec/views/curation_concerns/base/form.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/form.html.erb_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+def required_attributes
+  GenericWork.validators
+    .select{|v| v.is_a? ActiveModel::Validations::PresenceValidator}
+    .map{|v| v.attributes}
+    .flatten
+    .map(&:to_s)
+end
+
+describe "Work Edit Form" do
+  let(:work) {stub_model(GenericWork, id: '123')}
+  let(:ability) { nil }
+  let(:curation_concern) {work}
+  let(:work_form) {CurationConcerns::GenericWorkForm.new(work, ability)}
+
+  before do
+    # mock the helper method
+    allow(view).to receive(:curation_concern).and_return(work)
+    assign(:form, work_form)
+    assign(:main_app, main_app)
+
+    render partial: "curation_concerns/base/form.html.erb"
+  end
+
+  it "has html5 required attribute for required input fields" do
+    input_fields = ["title","creator","date_created"]
+    input_fields.each do |infield|
+      expect(rendered).to have_selector("input[id='generic_work_#{infield}']") do |selected|
+        expect(selected).to have_selector("required")
+      end
+    end
+  end
+
+  it "has html5 required attribute for required text area fields" do
+    texta_fields = ["title","creator","date_created"]
+    texta_fields.each do |tafield|
+      expect(rendered).to have_selector("input[id='generic_work_#{tafield}']") do |selected|
+        expect(selected).to have_selector("required")
+      end
+    end
+  end
+
+  it "has html5 required attribute for the rights attribute fields" do
+    texta_fields = ["title","creator","date_created"]
+    texta_fields.each do |tafield|
+      expect(rendered).to have_selector("input[id='generic_work_#{tafield}']") do |selected|
+        expect(selected).to have_selector("required")
+      end
+    end
+  end
+
+  # The rights selection by radio button needs to be selected using name instead of id
+  # because there are multiple elements that are used for the rights.
+  it "has html5 required attribute for all required attribute inputs" do
+    expect(rendered).to have_selector("input[name='generic_work[rights]']") do |selected|
+        expect(selected).to have_selector("required")
+    end
+  end
+end
+


### PR DESCRIPTION
Closes #248 from the UI side.  

### :warning: WARNING:  Change to rspec config in rails_helper allows mocking of any method in the view specs by disabling verified partial doubles in rspec.

Upstream fix is in CurationConcerns.
If the user makes a request without the UI validation catch, the model will fail validation an won't be saved.  The redirection to render the create page will fail, but that's the user's problem for circumventing the UI, and will be addressed by the upstream fix eventually.