### PR TITLE
add uniqname_ldap_roles service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ config/arkivo.yml
 config/zotero.yml
 config/ezid.yml
 config/clients_data/*
+config/mcommunity.yml
 
 # Ignore bundler config.
 /.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 
 # EZID client from Duke
 gem 'ezid-client'
+# LDAP client
+gem 'net-ldap'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.6'
 # Use sqlite3 as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,7 @@ GEM
     nest (1.1.2)
       redis
     net-http-persistent (2.9.4)
+    net-ldap (0.14.0)
     netrc (0.11.0)
     noid (0.8.0)
     nokogiri (1.6.7.2)
@@ -745,6 +746,7 @@ DEPENDENCIES
   jquery-rails
   kaminari!
   mysql2
+  net-ldap
   poltergeist
   pry
   pry-byebug

--- a/app/services/umrdr/uniqname_ldap_roles.rb
+++ b/app/services/umrdr/uniqname_ldap_roles.rb
@@ -1,0 +1,75 @@
+module Umrdr
+
+  require 'rubygems'
+  require 'net/ldap'
+
+# For local development you can use the https://www.incommon.org/cert/repository/InCommonServerCA.txt
+# as a certiticate for verifying the MCommunity LDAP server's certificate.
+# ENV['LDAPTLS_CACERT'] = '/www/www.lib/misc/bundle.crt';
+
+  class UniqnameLdapRoles
+
+    attr_accessor :uniqname
+
+    HOST = 'ldap.umich.edu'
+    PORT = 636
+    ENCRYPTION = :simple_tls
+    USERNAME =  'mcommunityuser'
+    PASSWORD = 'mcommunitypass'
+    AUTH = {:method => :simple, :username => USERNAME, :password => PASSWORD}
+
+    def self.uniqname_faculty_or_staff?(uname)
+      Umrdr::UniqnameLdapRoles.new(uname).run
+    end
+
+    def initialize(uname)
+      @uniqname = uname
+    end
+
+    # Errors returned rescue from ldap.open in run method can include
+    # "getaddrinfo: nodename nor servname provided, or not known" when HOST is wrong
+    # "Operation timed out - user specified timeout" when PORT is wrong
+    # "undefined method `umichinstroles' for #<Net::LDAP::Entry:OBJECT-NUMBER>" when  USERNAME is wrong
+    # "undefined method `umichinstroles' for #<Net::LDAP::Entry:OBJECT-NUMBER>" when  PASSWORD is wrong
+    # "Error: Invalid binding information" when the AUTH is wrong
+
+    def faculty_or_staff_roles?(umichinstroles)
+      faculty = staff = student = false
+
+      umichinstroles.each do |value|
+        faculty = value.downcase.include? "faculty"
+        staff = value.downcase.include? "regularstaff"
+        student = value.downcase.include? "student"
+      end
+
+      if faculty
+        return true
+      elsif (staff && ! student)
+        return true
+      else
+        return false
+      end
+
+    end
+
+    def run
+      begin
+        @ldap = Net::LDAP.open(:host => HOST, :port => PORT, :encryption => ENCRYPTION, :auth => AUTH) do |ldap|
+          # set up search
+          filter = Net::LDAP::Filter.eq('objectclass', '*')
+          treebase = "uid=#{@uniqname},ou=People,dc=umich,dc=edu"
+
+          ldap.search( :base => treebase, :filter => filter ) do |entry|
+            
+            return faculty_or_staff_roles?(entry.umichinstroles)
+
+          end # do |entry|
+        end # do |ldap|
+
+      rescue Exception, StandardError, Net::LDAP::ConnectionError, Net::LDAP::Error, SocketError, SystemCallError, OpenSSL::SSL::SSLError => e
+        raise "LDAP PROBLEM - Error: #{e}"
+      end
+    end
+
+  end
+end

--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ Dir.chdir APP_ROOT do
   config_file_targets = [ "config/database.yml", "config/secrets.yml", "config/blacklight.yml",
                           "config/fedora.yml", "config/solr.yml", "config/redis.yml",
                           "config/resque-pool.yml", "config/jetty.yml", "config/ezid.yml",
-                          "config/browse_everything_providers.yml"]
+                          "config/browse_everything_providers.yml", "config/mcommunity.yml"]
 
   config_file_targets.each do |t|
     src = "#{t}.sample"

--- a/config/mcommunity.yml.sample
+++ b/config/mcommunity.yml.sample
@@ -1,0 +1,14 @@
+development:
+  host: 'ldap.umich.edu'
+  port: 636
+  encryption: 'simple_tls'
+  use_ssl: true
+  user: "mcommunityuser"
+  password: "mcommunitypass"
+test:
+  host: 'ldap.umich.edu'
+  port: 636
+  encryption: 'simple_tls'
+  use_ssl: true
+  user: "mcommunityuser"
+  password: "mcommunitypass"

--- a/spec/services/uniqname_ldap_roles_spec.rb
+++ b/spec/services/uniqname_ldap_roles_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+require 'net/ldap'
+
+describe Umrdr::UniqnameLdapRoles do
+
+  context "when a uniqname is given" do
+
+    it "returns false for a uniqname known to have no ldap entry" do
+      umichinstroles = [" "]
+      test = described_class.new('gordonl').faculty_or_staff_roles?(umichinstroles)
+      expect(test).to be_falsey
+    end
+
+    it "returns false for a uniqname of a non-teaching student known to have an ldap entry" do
+      umichinstroles = ["StudentAA", "EnrolledStudentAA"]
+      test = described_class.new('gordonl').faculty_or_staff_roles?(umichinstroles)
+      expect(test).to be_falsey
+    end
+
+    it "returns false for a uniqname of a teaching student known to have an ldap entry" do
+      umichinstroles = ["StudentAA", "RegularStaffAA", "EnrolledStudentAA"]
+      test = described_class.new('gordonl').faculty_or_staff_roles?(umichinstroles)
+      expect(test).to be_falsey
+    end
+
+
+    it "returns false for a uniqname of an alumni" do
+      umichinstroles = ["AlumniAA"]
+      test = described_class.new('gordonl').faculty_or_staff_roles?(umichinstroles)
+      expect(test).to be_falsey
+    end
+
+    it "returns true for a uniqname of a regular staff" do
+      umichinstroles = ["RegularStaffAA"]
+      test = described_class.new('gordonl').faculty_or_staff_roles?(umichinstroles)
+      expect(test).to be_truthy
+    end
+
+    it "returns true for a uniqname of faculty member" do
+      umichinstroles = ["FacultyAA"]
+      test = described_class.new('gordonl').faculty_or_staff_roles?(umichinstroles)
+      expect(test).to be_truthy
+    end
+
+  end
+end


### PR DESCRIPTION
Improved code and spec for checking ldap institutional roles based on a given uniqname.

Now returns false for graduate students with a staff (usually teaching) role.

Still waiting to hear back from ITS.