### PR TITLE
Move default hostname config to environment.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,14 +17,15 @@ module Umrdr
     config.relative_url_root = '/data'
 
     # For properly generating URLs and minting DOIs - the app may not by default
-    # know its hostname if started via puma and accessed via mod_proxy.
-    config.hostname = 'umrdr-testing.quod.lib.umich.edu'
-    # URL for logging the user out of Cosign
-    config.logout_prefix = "https://weblogin.umich.edu/cgi-bin/logout?"
-    
+    # Outside of a request context the hostname needs to be provided.
+    config.hostname = ENV['UMRDR_HOST'] || 'umrdr.umich.edu'
+
     # Set the default host for resolving _url methods
     Rails.application.routes.default_url_options[:host] = config.hostname
 
+    # URL for logging the user out of Cosign
+    config.logout_prefix = "https://weblogin.umich.edu/cgi-bin/logout?"
+    
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,13 +4,6 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
-  # For properly generating URLs and minting DOIs - the app may not by default
-  # know its hostname if started via puma and accessed via mod_proxy.
-  config.hostname = 'deepblue.lib.umich.edu'
-
-  # Set the default host for resolving _url methods
-  Rails.application.routes.default_url_options[:host] = config.hostname
-
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.


### PR DESCRIPTION
Hostname will have to be handled by deployment configuration.

This is primarily used by the doi minting service.  Since that is not run in the context of a request, the rails url helper has no way of knowing the hostname.  Reading from `ENV['UMRDR_HOST']` during application initialization removes the need to hardcode the hostname the application is deployed to.  Supplying the environment variable can be handled by the systemd service.