### PR TITLE
Get redis namespace from env or use default.

### DIFF
--- a/config/initializers/curation_concerns.rb
+++ b/config/initializers/curation_concerns.rb
@@ -44,7 +44,7 @@ CurationConcerns.configure do |config|
   # config.minter_statefile = '/tmp/minter-state'
 
   # Specify the prefix for Redis keys:
-  # config.redis_namespace = "curation_concerns"
+  config.redis_namespace = ENV['REDIS_NS'] || "umrdr"
 
   # Specify the path to the file characterization tool:
   # config.fits_path = "fits.sh"


### PR DESCRIPTION
Deployment will have to provide the `ENV['REDIS_NS']` environment variable.  This will be handled by the systemd service that runs the application.