### PR TITLE
Push minter-statefile location to env config.

### DIFF
--- a/config/initializers/curation_concerns.rb
+++ b/config/initializers/curation_concerns.rb
@@ -3,9 +3,8 @@ CurationConcerns.configure do |config|
   config.register_curation_concern :generic_work
 
   config.max_days_between_audits = 7
-  config.minter_statefile = '/tmp/umrdr-minter'
 
-  config.minter_statefile = '/tmp/grosscol-umdr'
+  config.minter_statefile = ENV['MINTER_FILE'] || "/tmp/umrdr-minter-#{Time.now.min}#{Time.now.sec}"
 
   config.display_microdata = true
   config.microdata_default_type = 'http://schema.org/CreativeWork'

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -4,8 +4,6 @@ Sufia.config do |config|
     file_author: :creator
   }
 
-  config.minter_statefile = Rails.env.production? ? '/var/deepbluedata/minter-state' : '/tmp/grosscol-umrdr'
-
   config.max_days_between_audits = 7
 
   config.max_notifications_for_dashboard = 5


### PR DESCRIPTION
Deployment will have to provide the ENV['MINTER_FILE'] environment variable. This will be handled by the systemd service that runs the application.

In conjunction with #302, multiple deployments should be able to live side by side on the same server.