### PR TITLE
Fix typo in updating Rights from 3.0 to 4.0

### DIFF
--- a/config/authorities/rights.yml
+++ b/config/authorities/rights.yml
@@ -1,14 +1,19 @@
 terms:
     - id: http://creativecommons.org/publicdomain/zero/1.0/
       term: CC0 1.0 Universal
-    - id: http://creativecommons.org/licenses/by/3.0/us/
+      active: true
+    - id: http://creativecommons.org/licenses/by/4.0/
       term: Attribution 4.0 United States
-    - id: http://creativecommons.org/licenses/by-nc/3.0/us/
+      active: true
+    - id: http://creativecommons.org/licenses/by-nc/4.0/
       term: Attribution-NonCommercial 4.0 United States
-    # - id: http://creativecommons.org/licenses/by-nd/3.0/us/
-    #   term: Attribution-NoDerivs 3.0 United States
-    # - id: http://creativecommons.org/licenses/by-sa/3.0/us/
-    #   term: Attribution-ShareAlike 3.0 United States
+      active: true
+    - id: http://creativecommons.org/licenses/by-nd/3.0/us/
+      term: Attribution-NoDerivs 3.0 United States
+      active: false
+    - id: http://creativecommons.org/licenses/by-sa/3.0/us/
+      term: Attribution-ShareAlike 3.0 United States
+      active: false
     # - id: http://creativecommons.org/licenses/by-nc-nd/3.0/us/
     #   term: Attribution-NonCommercial-NoDerivs 3.0 United States
     # - id: http://creativecommons.org/licenses/by-nc-nd/3.0/us/

--- a/config/initializers/rights_service_patch.rb
+++ b/config/initializers/rights_service_patch.rb
@@ -1,0 +1,11 @@
+# Patch RightsService to only return active terms from select_options,
+# but still allow resolving the inactive terms for legacy support.
+RightsService.module_eval do
+  def self.select_options
+    active_elements.map{ |e| [e[:label], e[:id]] }
+  end
+
+  def self.active_elements
+    authority.all.select{ |e| authority.find(e[:id])[:active] }
+  end
+end

--- a/config/locales/umrdr.en.yml
+++ b/config/locales/umrdr.en.yml
@@ -156,6 +156,15 @@ en:
     http://creativecommons_org/publicdomain/zero/1_0/:
       description:
         "You dedicate this work to the public domain, waiving all your rights to the work worldwide under copyright law."
+    http://creativecommons_org/licenses/by/4_0/:
+      description:
+        "This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation."
+    http://creativecommons_org/licenses/by-nc/4_0/:
+      description:
+        "This license lets others modify and build upon your work non-commercially. Their new works must also acknowledge you and be non-commercial, but they don’t have to license their derivative works on the same terms."
+    http://creativecommons_org/licenses/by-nd/4_0/:
+      description:
+        "This license allows for redistribution, commercial and non-commercial, as long as it is passed along unchanged and in whole, with credit to you."
     http://creativecommons_org/licenses/by/3_0/us/:
       description:
         "This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation."

--- a/spec/fixtures/authorities/rights.yml
+++ b/spec/fixtures/authorities/rights.yml
@@ -1,0 +1,13 @@
+terms:
+    - id: demo_id_01
+      term: First Active Term
+      active: true
+    - id: demo_id_02
+      term: Second Active Term
+      active: true
+    - id: demo_id_03
+      term: Third is an Inactive Term
+      active: false
+    - id: demo_id_04
+      term: Fourth is an Inactive Term
+      active: false

--- a/spec/services/rights_service_patch_spec.rb
+++ b/spec/services/rights_service_patch_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe RightsService do
+  before do
+    # Configure QA to use fixtures
+    qa_fixtures ={local_path: File.expand_path('../../fixtures/authorities', __FILE__)}
+    stub_const("Qa::Authorities::LocalSubauthority::AUTHORITIES_CONFIG", qa_fixtures)
+  end
+
+  describe "#select_options" do
+    it "returns active terms" do
+      expect(RightsService.select_options).to include(["First Active Term", "demo_id_01"], ["Second Active Term", "demo_id_02"])
+    end
+
+    it "does not return inactive terms" do
+      expect(RightsService.select_options).not_to include(["Third is an Inactive Term", "demo_id_03"], ["Fourth is an Inactive Term", "demo_id_04"])
+    end
+  end
+
+  describe "#label" do
+    it "resolves for ids of active terms" do
+      expect(RightsService.label('demo_id_01')).to eq("First Active Term")
+    end
+
+    it "resolves for ids of inactive terms" do
+      expect(RightsService.label('demo_id_03')).to eq("Third is an Inactive Term")
+    end
+  end
+end


### PR DESCRIPTION
There was a typo linking to the incorrect rights statement for the label.  Specifically, the 4.0 licenses pointed to 3.0 links.

Additionally, this supports adding new rights while supporting previous rights.  The `active` key is added to indicate if the term is appropriate for current use.  The `RightsService` will only return active terms for calls to `select_options` but will still resolve the terms for `active=false` ids.

Supersedes #321