### PR TITLE
Create static terms of use page

### DIFF
--- a/app/views/static/terms.html
+++ b/app/views/static/terms.html
@@ -1,0 +1,31 @@
+﻿<h1>Terms of Use</h1>
+
+<h2>For Depositors</h2>
+
+<p>You are solely responsible for the contents of your deposit and agree that University of Michigan is not responsible for the contents of your deposit.</p>
+
+<p>You represent and warrant that:</p>
+
+<ul>
+  <li>the deposit is your original work, and/or that you have the authority to authorize the uses contained in the license you have selected for your deposit;</li>
+  <li>if your deposit contains material that is not your original work, either you have the right to deposit the materials in this context or you have obtained the necessary permission to do so.</li>
+  <li>any third-party material is clearly and appropriately identified and acknowledged in the content of the deposit</li>
+  <li>your deposit does not infringe upon anyone&apos;s rights (e.g., copyright, privacy, defamation, etc.), breach a contract, violate the law, or contain unlawful material.</li>
+</ul>
+
+<p>You are responsible for ensuring that Research data involving the use of human subjects is in accordance with the <a href="#">University of Michigan&apos;s Institutional Review Board (IRB)</a>.</p>
+
+<p>You understand and agree that Deep Blue services are provided "as is" without warranty of any kind, either express or implied, including without limitation, the implied warranties of merchantability or fitness for a particular purpose.</p>
+
+<p>You understand and agree that if the Library determines that the terms of service have been violated, it may limit or remove access to the deposited material in question, leaving descriptive metadata and a notice to explain the reason for the removal. The descriptive metadata and the notice will be visible to those who have its persistent URL.</p>
+
+<h2>For Users</h2>
+
+<p>If you view or download information from Deep Blue repositories, you agree that Deep Blue services and content therein are provided "as is" without warranty of any kind, either express or implied, including without limitation, the implied warranties of merchantability or fitness for a particular purpose. Use of Deep Blue Data is at your own risk.</p>
+
+<p>You agree that Deep Blue repositories and its administrator, the University of Michigan, shall have no liability for any consequential, indirect, punitive, special or incidental damages, whether foreseeable or unforeseeable (including, but not limited to, claims for defamation, errors, loss of data, or interruption in availability of data), arising out of or relating to your use of Deep Blue repositories or any resource that you access through Deep Blue repositories.</p>
+
+<p>Deep Blue repositories host content from a number of authors. The statements and views of these authors are theirs alone, and do not reflect the stances or policies of the University of Michigan or their sponsors, nor does their posting imply the endorsement of the University of Michigan or their sponsors.</p>
+
+<p>Deep Blue repositories collect usage data. The U-M Library has a <a href="http://www.lib.umich.edu/library-administration/user-privacy-policy-university-library">revised statement on privacy and confidentiality</a> on how these data are collected and used.</p>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,7 @@ Rails.application.routes.draw do
   mount BrowseEverything::Engine => '/browse'
   mount Blacklight::Engine => '/'
 
-  get 'terms', to: proc { [302, { 'Location' => 'agreement'}, []] }
-  get ':action' => 'static#:action', constraints: { action: /about|help|use-downloaded-data|support-for-depositors|file-format-preservation|how-to-upload|prepare-your-data|retention|zotero|mendeley|agreement|subject_libraries|versions/ }, as: :static
+  get ':action' => 'static#:action', constraints: { action: /about|help|use-downloaded-data|support-for-depositors|file-format-preservation|how-to-upload|prepare-your-data|retention|zotero|mendeley|agreement|terms|subject_libraries|versions/ }, as: :static
 
   concern :searchable, Blacklight::Routes::Searchable.new
 


### PR DESCRIPTION
Closes #320 

@amyneeser, @grosscol and @njaffer: Because `/terms` was forwarding to `/agreement` we may not have to change any links, but someone should do a once over to make sure that the right pages are linked to in the right places.