### PR TITLE
Add fits.sh hardcoded path to both sufia and cc initializers

### DIFF
--- a/config/initializers/curation_concerns.rb
+++ b/config/initializers/curation_concerns.rb
@@ -46,7 +46,7 @@ CurationConcerns.configure do |config|
   config.redis_namespace = ENV['REDIS_NS'] || "umrdr"
 
   # Specify the path to the file characterization tool:
-  # config.fits_path = "fits.sh"
+  config.fits_path = system("which", "fits.sh") ? "fits.sh" : "/l/local/fits/fits.sh"
 
   # Specify a date you wish to start collecting Google Analytic statistics for.
   # Leaving it blank will set the start date to when ever the file was uploaded by

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -68,7 +68,7 @@ Sufia.config do |config|
   # config.redis_namespace = "sufia"
 
   # Specify the path to the file characterization tool:
-  # config.fits_path = "fits.sh"
+  config.fits_path = system("which", "fits.sh") ? "fits.sh" : "/l/local/fits/fits.sh"
 
   # Specify how many seconds back from the current time that we should show by default of the user's activity on the user's dashboard
   # config.activity_to_show_default_seconds_since_now = 24*60*60


### PR DESCRIPTION
Not entirely sure which one should be used for the intermediate stage we're on.  If `fits.sh` is defined in the path, the resulting command will be `fits.sh`.  Otherwise, it will use the hardcoded path that is stable for staging and production.