### PR TITLE
Correct file_set analytics link

### DIFF
--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -1,0 +1,21 @@
+<div class="form-actions">
+  <% if Sufia.config.analytics %>
+    <% # TODO remove this hideous hack, and correct behavior to respect url root in Sufia. %>
+    <%= link_to "Analytics", main_app.root_path.chomp('/') + @presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
+  <% end %>
+  <% if Sufia.config.citations %>
+    <%= link_to "Citations", sufia.citations_work_path(@presenter), id: 'citations', class: 'btn btn-default' %>
+  <% end %>
+  <% if @presenter.editor? %>
+      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]),
+                  class: 'btn btn-default' %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter],
+                  class: 'btn btn-danger', data: { confirm: "Delete this #{@presenter.human_readable_type}?" },
+                  method: :delete %>
+      <%= link_to t('sufia.single_use_links.button'),
+                  curation_concerns.generate_download_single_use_link_path(@presenter),
+                  class: 'btn btn-default generate-single-use-link' %>
+  <% end %>
+
+  <%= render 'social_media' %>
+</div>


### PR DESCRIPTION
  Override entire file_set show actions partial in order to correct the analytics link on the file set show page.