### PR TITLE
Update two broken gemspecs and the resulting Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Added Gems
-gem 'sufia', '~> 7.0'
+gem 'sufia', '~> 7.1.0'
 # EZID client from Duke
 gem 'ezid-client'
 # LDAP client
@@ -50,7 +50,7 @@ group :development, :test do
   gem 'factory_girl_rails', require: false
   gem 'rspec-rails'
   gem 'rspec-activemodel-mocks'
-  gem 'solr_wrapper', '>= 0.3'
+  gem 'solr_wrapper', '>= 0.19'
   gem 'fcrepo_wrapper', '~> 0.1'
   gem 'capybara'
   gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,7 +611,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (3.6.0)
-    solr_wrapper (0.18.0)
+    solr_wrapper (0.19.0)
       faraday
       ruby-progressbar
       rubyzip
@@ -751,12 +751,12 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  solr_wrapper (>= 0.3)
+  solr_wrapper (>= 0.19)
   sqlite3
-  sufia (~> 7.0)
+  sufia (~> 7.1.0)
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.13.2
+   1.13.5


### PR DESCRIPTION
* solr_wrapper needed to be updated, as the former version relied
  on downloading a no-longer-available version of solr
* sufia needed to be nailed down to 7.1.0 until the 7.2 release is
  fixed to not rely on a github-hosted fork of flipflop.