### PR TITLE
Update solr_wrapper to use available version of solr

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,7 +611,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (3.6.0)
-    solr_wrapper (0.18.0)
+    solr_wrapper (0.19.0)
       faraday
       ruby-progressbar
       rubyzip
@@ -759,4 +759,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.13.2
+   1.13.6


### PR DESCRIPTION
Ran `bundle update solr_wrapper` to just update the one gem. 

Seth had to tell me you could do that.