### PR TITLE
Add a default, fake email address for the TO field

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # In test, go ahead and have a default to address for email
+
+  config.notification_email = 'fake@sample.com'
 end


### PR DESCRIPTION
Fixes a failing test when a default "TO:" value is not set.

Only in test environments, we'll go ahead and pretend to
send email to nobody. Might want to include a check in
the deploy scripts to make sure one is configured for an
actual run?