### PR TITLE
Smaller icon on works display page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Added Gems
-gem 'sufia', '~> 7.0'
+gem 'sufia', '~> 7.0.0'
 # EZID client from Duke
 gem 'ezid-client'
 # LDAP client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,7 +611,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (3.6.0)
-    solr_wrapper (0.18.0)
+    solr_wrapper (0.19.0)
       faraday
       ruby-progressbar
       rubyzip
@@ -759,4 +759,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.13.2
+   1.13.6

--- a/app/assets/stylesheets/custom_layout/tweaks.css
+++ b/app/assets/stylesheets/custom_layout/tweaks.css
@@ -35,3 +35,11 @@ ol.catalog li:after {
   text-align: left;
   font-size: 1.2em;
 }
+
+
+/* Make the PDF icon not as big as my head */
+
+.pdficon {
+    max-width: 8em;
+}
+

--- a/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
@@ -1,0 +1,22 @@
+<% if Sufia.config.display_media_download_link %>
+    <div>
+      <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media pdficon",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to main_app.download_path(file_set),
+                  target: :_blank,
+                  data: { turbolinks: false },
+                  class: "btn btn-default" do %>
+          <%= t('curation_concerns.show.downloadable_content.pdf_link') %>
+      <% end %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media pdficon",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # In test, go ahead and have a default to address for email
+
+  config.notification_email = 'fake@sample.com'
 end


### PR DESCRIPTION
Addresses #455. Added a 'pdficon' class to the appropriate places so it can be sized independently.

![image](https://cloud.githubusercontent.com/assets/114006/20225190/0ed0c8e4-a810-11e6-9c94-d5ab454ac10a.png)
