### PR TITLE
Make pdf icon a more reasonable size

### DIFF
--- a/app/assets/stylesheets/custom_layout/tweaks.css
+++ b/app/assets/stylesheets/custom_layout/tweaks.css
@@ -35,3 +35,11 @@ ol.catalog li:after {
   text-align: left;
   font-size: 1.2em;
 }
+
+
+/* Make the PDF icon not as big as my head */
+
+.pdficon {
+    max-width: 8em;
+}
+

--- a/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
@@ -1,0 +1,22 @@
+<% if Sufia.config.display_media_download_link %>
+    <div>
+      <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media pdficon",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to main_app.download_path(file_set),
+                  target: :_blank,
+                  data: { turbolinks: false },
+                  class: "btn btn-default" do %>
+          <%= t('curation_concerns.show.downloadable_content.pdf_link') %>
+      <% end %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media pdficon",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>


### PR DESCRIPTION
Customized the PDF type tempalte to include class
`pdficon` that sets its size to 8em.

Addresses #455

![image](https://cloud.githubusercontent.com/assets/114006/20231081/533fc18e-a82d-11e6-9f61-161f5fbcc534.png)
