### PR TITLE
Make remove buttons in work creation readable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Added Gems
-gem 'sufia', '~> 7.0'
+gem 'sufia', '~> 7.0.0'
 # EZID client from Duke
 gem 'ezid-client'
 # LDAP client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,7 +611,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (3.6.0)
-    solr_wrapper (0.18.0)
+    solr_wrapper (0.19.0)
       faraday
       ruby-progressbar
       rubyzip
@@ -759,4 +759,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.13.2
+   1.13.6

--- a/app/assets/stylesheets/custom_layout/tweaks.css
+++ b/app/assets/stylesheets/custom_layout/tweaks.css
@@ -16,6 +16,7 @@ ol.catalog li:after {
 .multi_value .field-controls .btn.add, 
 .multi_value .field-controls .btn.remove {
     width: 15em;
+    color: white;
 }
 
 .attributes .attribute {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # In test, go ahead and have a default to address for email
+
+  config.notification_email = 'fake@sample.com'
 end


### PR DESCRIPTION
Just made the text white as a stopgap.

Addresses issue #444 

![screen shot 2016-11-11 at 5 19 31 pm](https://cloud.githubusercontent.com/assets/114006/20231971/3b5f3774-a833-11e6-8022-642d501f80e1.png)
