### PR TITLE
Eliminate links to collections and works on profile page

### DIFF
--- a/app/views/users/_vitals.html.erb
+++ b/app/views/users/_vitals.html.erb
@@ -1,0 +1,30 @@
+<div class="list-group-item">
+  <span class="glyphicon glyphicon-time"></span> Joined on <%= user.created_at.to_date.strftime("%b %d, %Y") %>
+</div>
+
+
+<%# Collections/works are showing the total number of items across all users.
+    Disable until this is fixed upstream. %>
+
+<% if false %>
+  <div class="list-group-item">
+    <span class="badge"><%= number_of_collections(user) %></span>
+    <span class="glyphicon glyphicon-folder-open"></span> <%= link_to_field('depositor', user.to_s, t("sufia.dashboard.stats.collections"), human_readable_type: "Collection") %>
+  </div>
+<% end %>
+
+<div class="list-group-item">
+
+  <%# Ditto. Upstream code shows *all* works, not just this user.
+      Comment out (using `if false`) until this is fixed
+  %>
+  <% if false %>
+    <span class="badge"><%= number_of_works(user) %></span>
+    <span class="glyphicon glyphicon-upload"></span> <%= link_to_field('depositor', user.to_s, t("sufia.dashboard.stats.works"),  human_readable_type: "Work") %>
+  <% end %>
+
+  <ul class="views-downloads-dashboard list-unstyled">
+      <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("sufia.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
+      <li><span class="badge badge-optional"><%= user.total_file_downloads %></span> <%= t("sufia.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
+  </ul>
+</div>


### PR DESCRIPTION
Upstream sufia code shows all collections/works for _all_ users.
Eliminate those links until it's fixed. Addresses #442.

## New display

![image](https://cloud.githubusercontent.com/assets/114006/20277665/8d998ae2-aa6f-11e6-927b-d69e84202a27.png)
