### PR TITLE
In production, use `./tmp/derivatives` as libreoffice temp dir

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,14 @@
+# Attempt to set tmpdir for libreoffice, as per
+# https://wiki.openoffice.org/wiki/Environment_Variables
+#
+# see also: https://forum.openoffice.org/en/forum/viewtopic.php?f=15&t=48217&p=221969&hilit=NamedPath#p221969
+# for an example of setting a path (we want "TEMP", not "WORK"), but I don't know where to set it.
+#
+# It's possible that we can mess with /etc/libreoffice/sofficerc, too, but I don't know how.
+
+tmpdir =  File.join(Rails.root, 'tmp', 'derivatives')
+ENV['TMPDIR'] = tmpdir;
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
Addresses (more of? all of?) #467. Ping to @sethaj 

LibreOffice gets its temporary directory from the environment variable
`TMPDIR`, if set. Use the rails-root `tmp/derivatives` in production
so `/tmp/` doesn't fill up.

NOTE: May also need to check out ClamAV. If that too is a problem, possible
solution is to add a line to `config/initializers/clamav.rb` as
per [the ClamAV specs](https://github.com/eagleas/clamav/blob/adac6261cbe8f24c1fc9e8044e7ae9d280641921/spec/unit/clamav_spec.rb#L145)

```ruby

ClamAV.instance.setstring(CL_ENGINE_TMPDIR, 'the/temp/dir/you/want')

```