### PR TITLE
Fix #454 - Improve Cosign logout process

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,4 +37,12 @@ class ApplicationController < ActionController::Base
   def user_logged_in?
     user_signed_in? && ( valid_user?(request.headers) || Rails.env.test?)
   end
+
+  def sso_logout
+    redirect_to Sufia::Engine.config.logout_prefix + logout_now_url
+  end
+
+  def sso_auto_logout
+    cookies.delete("cosign-" + Sufia::Engine.config.hostname, domain: Sufia::Engine.config.hostname)
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,10 @@
 class SessionsController < ApplicationController
   def destroy
-    sign_out(:user)
-    cookies.delete("cosign-" + Sufia::Engine.config.hostname)
-    redirect_to Sufia::Engine.config.logout_prefix + root_url
+    if user_signed_in?
+      sso_logout
+    else
+      logout_now
+    end
   end
 
   def new
@@ -13,5 +15,12 @@ class SessionsController < ApplicationController
       # should have been redirected via mod_cosign - error out instead of going through redirect loop
       render(:status => :forbidden, :text => 'Forbidden')
     end
+  end
+
+  def logout_now
+    Rails.logger.info "Logging out, hostname: #{Sufia::Engine.config.hostname}"
+    sign_out(:user)
+    sso_auto_logout
+    redirect_to root_url
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   end
 
   devise_for :users, path: '', path_names: {sign_in: 'login', sign_out: 'logout'}, controllers: {sessions: 'sessions'}
+  get '/logout_now', to: 'sessions#logout_now'
 
   Hydra::BatchEdit.add_routes(self)
 


### PR DESCRIPTION
 * Defer terminating the session until logout is confirmed
 * Purge Cosign cookie upon logout confirmation

There is a new route, `/logout_now`, which triggers the confirmation and
redirects to the front page. It is never actually seen by the user
because it serves only to terminate sessions and redirect, but it does
no harm if a user visits the URL directly.

This change is clunky to test for two reasons:

First, Devise triggers a login on any presence of the remote user
header. Because the Rack middleware that generates fake headers for easy
login in development is unconditional and requires restart to disable,
logging out results in an immediate login on the front page. Working
around this requires setting up a reverse proxy and disabling the
middleware.

Second, to test the full two-stage logout, an actual Cosign config is
required. This means that it is really only practical to test in staging
on a real hostname.