### PR TITLE
Fix #500 - Redirect / to app root

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,10 +1,26 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-  
-map Umrdr::Application.config.relative_url_root || "/" do
+
+APP_ROOT = Umrdr::Application.config.relative_url_root || "/"
+
+map APP_ROOT do
   run Rails.application
 end
-  
-  
-  
+
+# Auto-redirect root URL hits to the app as a development convenience
+if "/" != APP_ROOT
+  map "/" do
+    run ->(env) do
+      req = Rack::Request.new(env)
+      res = Rack::Response.new
+      if req.path =~ /^\/*$/
+        res.redirect(APP_ROOT)
+      else
+        res.status = 404
+        res.write "The requested URL #{req.fullpath} was not found."
+      end
+      res.finish
+    end
+  end
+end


### PR DESCRIPTION
This is a small change to the rackup file that redirects '/' to the
application if not mounted at the root. It checks the requested path
and only redirects things that would resolve to the root (any number
of slashes, but nothing else).