### PR TITLE
if work is new, only show active licenses. If work is not new, show all the licenses.

### DIFF
--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -1,4 +1,11 @@
+<% if ((RightsService.select_active_options.dup.join(",").split(',').include? (curation_concern.rights[0])) || (curation_concern.date_uploaded==nil) )%>
 <% options = RightsService.select_active_options.dup %>
+<% else %>
+<% options = RightsService.select_all_options.dup %>
+<% end %>
+
+<%= curation_concern.rights[0] %>
+<%= RightsService.select_active_options %>
 <div class="form-group radio_buttons generic_work_rights">
     <%= f.label :rights %>
     <%= f.hint :rights %>

--- a/spec/records/edit_fields/_rights.html.erb_spec.rb
+++ b/spec/records/edit_fields/_rights.html.erb_spec.rb
@@ -10,31 +10,71 @@ describe 'records/edit_fields/_rights.html.erb', type: :view do
   end
   let(:ability) { double }
 
+  let(:curation_concern) {work}
+
   let(:form) do
     CurationConcerns::GenericWorkForm.new(work, ability)
   end
 
   let(:current_user) { sub_model(User) }
 
-  let(:f) do
+  let(:f_new) do
+    work.rights = nil
+    curation_concern = work
     SimpleForm::FormBuilder.new('generic-work', work, view, {})
   end
 
-  before do
+  let(:f_active_right) do
+    work.rights = ["http://rightsstatements.org/vocab/InC/1.0/"]
+    curation_concern = work
+    SimpleForm::FormBuilder.new('generic-work', work, view, {})
+  end
+
+  let(:f_inactive_right) do
+    work.rights = ["http://creativecommons.org/licenses/by-sa/3.0/us/"]
+    curation_concern = work
+    SimpleForm::FormBuilder.new('generic-work', work, view, {})
+  end
+
+  it "rights should have asides and descriptions for new work" do
+
     assign(:form, form)
-    render partial: "records/edit_fields/rights", locals: { f: f }
-  end
+    allow(view).to receive(:curation_concern).and_return(work) 
+    render partial: "records/edit_fields/rights", locals: { f: f_new }
 
-  it "rights should have asides" do
-    num_asides = RightsService.select_options.length
+    num_asides = RightsService.select_active_options.length
     expect(rendered).to have_selector(".generic_work_rights .radio aside", count: num_asides)
-  end
 
-  it "rights should have descriptions for each right" do
-    num_asides = RightsService.select_options.length
     RightsService.select_options.each do |right|
       expect(rendered).to have_content(t_uri(:description, scope: [ :rights, right[1] ]))
     end
   end
 
+  it "rights should have asides and descriptions for work with active right" do
+
+    assign(:form, form)
+    allow(view).to receive(:curation_concern).and_return(work) 
+    render partial: "records/edit_fields/rights", locals: { f: f_active_right }
+
+    num_asides = RightsService.select_active_options.length
+    expect(rendered).to have_selector(".generic_work_rights .radio aside", count: num_asides)
+
+    RightsService.select_options.each do |right|
+      expect(rendered).to have_content(t_uri(:description, scope: [ :rights, right[1] ]))
+    end
+  end
+
+  it "rights should have asides and descriptions for work with inactive right" do
+
+    assign(:form, form)
+    allow(view).to receive(:curation_concern).and_return(work) 
+    render partial: "records/edit_fields/rights", locals: { f: f_inactive_right }
+
+    num_asides = RightsService.select_active_options.length
+    expect(rendered).to have_selector(".generic_work_rights .radio aside", count: num_asides)
+
+    RightsService.select_options.each do |right|
+      expect(rendered).to have_content(t_uri(:description, scope: [ :rights, right[1] ]))
+    end
+  end
 end

--- a/spec/views/batch_edits/edit.html.erb_spec.rb
+++ b/spec/views/batch_edits/edit.html.erb_spec.rb
@@ -2,12 +2,15 @@ require 'spec_helper'
 
 RSpec.describe 'batch_edits/edit.html.erb' do
   let(:generic_work) { stub_model(GenericWork, id: nil, depositor: 'bob', rights: ['']) }
+  let(:curation_concern) {generic_work}
 
   before do
     allow(controller).to receive(:current_user).and_return(stub_model(User))
     assign :names, ['title 1', 'title 2']
     assign :terms, [:description, :rights]
     assign :generic_work, generic_work
+    allow(view).to receive(:curation_concern).and_return(generic_work)
+
     view.lookup_context.view_paths.push "#{CurationConcerns::Engine.root}/app/views/curation_concerns/base"
     render
   end


### PR DESCRIPTION
This Fixes #333 