### PR TITLE
Read hostname from settings if not in environment - #454

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module Umrdr
 
     # For properly generating URLs and minting DOIs - the app may not by default
     # Outside of a request context the hostname needs to be provided.
-    config.hostname = ENV['UMRDR_HOST'] || 'umrdr.umich.edu'
+    config.hostname = ENV['UMRDR_HOST'] || Settings.umrdr_host
 
     # Set the default host for resolving _url methods
     Rails.application.routes.default_url_options[:host] = config.hostname

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,2 +1,3 @@
 ---
 # Settings common to all environments go here
+umrdr_host: dev.deepblue.lib.umich.edu

--- a/config/settings/development.yml.sample
+++ b/config/settings/development.yml.sample
@@ -1,3 +1,4 @@
+umrdr_host: dev.deepblue.lib.umich.edu
 minter_file: <%= ENV['MINTER_FILE'] || "/tmp/umrdr-minter-#{Time.now.min}#{Time.now.sec}" %>
 redis_namespace: <%= ENV['REDIS_NS'] || "umrdr-dev" %>
 

--- a/config/settings/production.yml.sample
+++ b/config/settings/production.yml.sample
@@ -1,3 +1,4 @@
+umrdr_host: deepblue.lib.umich.edu
 minter_file: <%= ENV['MINTER_FILE'] || "/tmp/umrdr-minter-#{Time.now.min}#{Time.now.sec}" %>
 redis_namespace: <%= ENV['REDIS_NS'] || "umrdr-production" %>
 

--- a/config/settings/test.yml.sample
+++ b/config/settings/test.yml.sample
@@ -1,3 +1,4 @@
+umrdr_host: test.deepblue.lib.umich.edu
 minter_file: <%= ENV['MINTER_FILE'] || "/tmp/umrdr-minter-#{Time.now.min}#{Time.now.sec}" %>
 redis_namespace: <%= ENV['REDIS_NS'] || "umrdr-test" %>
 


### PR DESCRIPTION
This changes the literal hostname default that was in application.rb to
use Settings, so it can be set per environment and deployment target
more easily. If present, the UMRDR_HOST environment variable still takes
precedence.