### PR TITLE
Quiet asset logging in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,6 +15,9 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
+  # Don't log all the asset requests
+  config.assets.quiet = true
+
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.


### PR DESCRIPTION
Reduced noise in the logs by  not logging every GET for a file in `assets/`. I don't know what use those serve, but it'd be nice to have have to sort through them.