### PR TITLE
Fix up remaining logout/flash issues (#454)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,17 +9,17 @@ class SessionsController < ApplicationController
 
   def new
     if user_signed_in?
+      Rails.logger.debug "[AUTHN] sessions#new, redirecting"
       # redirect to where user came from (see Devise::Controllers::StoreLocation#stored_location_for)
       redirect_to stored_location_for(:user) || sufia.dashboard_index_path
     else
+      Rails.logger.debug "[AUTHN] sessions#new, failed because user_signed_in? was false"
       # should have been redirected via mod_cosign - error out instead of going through redirect loop
       render(:status => :forbidden, :text => 'Forbidden')
     end
   end
 
   def logout_now
-    Rails.logger.info "Logging out, hostname: #{Sufia::Engine.config.hostname}"
-    sign_out(:user)
     sso_auto_logout
     redirect_to root_url
   end

--- a/lib/devise/strategies/http_header_authenticatable.rb
+++ b/lib/devise/strategies/http_header_authenticatable.rb
@@ -12,6 +12,7 @@ module Devise
       def authenticate!
         user = remote_user(request.headers)
         if user.present?
+          Rails.logger.debug "[AUTHN] HttpHeaderAuthenticatable#authenticate! succeeded: #{user}"
           u = User.find_by_user_key(user)
           if u.nil?
             u = User.create(email: user)
@@ -19,6 +20,7 @@ module Devise
           end
           success!(u)
         else
+          Rails.logger.debug '[AUTHN] HttpHeaderAuthenticatable#authenticate! failed.'
           fail!
         end
       end


### PR DESCRIPTION
Fixes #393
Fixes #454
Fixes #463

 * Add secure flag for proper cookie deletion
 * Clear session and flash on logout
 * Add a Warden after_authentication block to clear the flash on login
 * Add debug logging for various authentication events

This is still not perfect in that it does not detect if the REMOTE_USER
changes while the Cosign cookie has not timed out. This could happen if
someone logs out through another window, logs in as another user, and
then refreshes or clicks a link. The Rails session will persist with the
old identity.

The reason this change does not address that issue is that, because of
the way Devise works and the strategy is implemented, the notion of the
REMOTE_USER is not visible at the controller layer, which has the filter
to check for a missing user (and terminate the session).

The solution to this is to pull the knowledge of how to determine the
REMOTE_USER for the request out of the Devise layer, and use it from
both the strategy and the controller. Then, the Warden authentication
event can set the remote user or SSO session ID in the Rails session,
and the filter can check whether the user value has changed. I decided
that this was a larger change than I wanted to make for the base issue.
It can be taken up as another issue to improve the edge case behavior.