### PR TITLE
Delete cookie with proper flags

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,8 +43,7 @@ class ApplicationController < ActionController::Base
   def sso_auto_logout
     Rails.logger.debug "[AUTHN] sso_auto_logout: #{current_user.try(:email) || '(no user)'}"
     sign_out(:user)
-    cookies.delete("cosign-" + Sufia::Engine.config.hostname,
-                   domain: Sufia::Engine.config.hostname, secure: true)
+    cookies.delete("cosign-" + Sufia::Engine.config.hostname, path: '/')
     session.destroy
     flash.clear
   end


### PR DESCRIPTION
The problem with the other versions of the cookie deletion was that the
Cosign cookie is a "host-only" cookie. This is accomplished by not
setting the domain at all. The first attempt introduced the domain,
which made everything else fail. This is the correct approach, which
expires the host-only cookie (no domain sent) at the path of /. This
matches the existing cookie, deleting it as expected. The secure flag is
irrelevant because we are sending a new cookie, which expires
immediately.