### PR TITLE
to allow google scholar to crawl us. change here will display metadata in header used by google scholar.

### DIFF
--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -1,3 +1,4 @@
+<%= render 'shared/citations' %>
 <% provide :page_title, construct_page_title(@presenter.page_title) %>
 <% provide :page_header do %>
   <h1 class="main-heading"><%= @presenter %></h1>


### PR DESCRIPTION
Fixes #36 . Adds metadata for Twitter and Google Scholar. Part of Sufia code