### PR TITLE
Update resque/redis namespace directives

### DIFF
--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -14,7 +14,7 @@ if defined?(PhusionPassenger)
                  nil
                end
       Resque.redis = $redis
-      Resque.redis.namespace = "#{CurationConcerns.config.redis_namespace}:#{Rails.env}"
+      Resque.redis.namespace = Settings.redis_namespace
       Resque.redis.client.reconnect if Resque.redis
     end
   end

--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -3,4 +3,5 @@ config = YAML.load(ERB.new(IO.read(File.join(Rails.root, 'config', 'redis.yml'))
 Resque.redis = Redis.new(host: config[:host], port: config[:port], thread_safe: true)
 
 Resque.inline = Rails.env.test?
-#Resque.redis.namespace = "#{CurationConcerns.config.redis_namespace}:#{Rails.env}"
+Resque.redis.namespace = Settings.resque_namespace || 'umrdr_dev_of_some_kind'
+Rails.logger.info "Rescue namespace is #{Settings.resque_namespace}"

--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -4,6 +4,5 @@ Resque.redis = Redis.new(host: config[:host], port: config[:port], thread_safe: 
 
 Resque.inline = Rails.env.test?
 
-Resque.redis.namespace = ENV['REDIS_NS'] || 'umrdr_dev_of_some_kind'
-Rails.logger.info "Rescue namespace is #{Resque.redis.namespace}"
-Rails.logger.info "Rescue REDIS_NS environment variable is #{ENV['REDIS_NS']}"
+Resque.redis.namespace = Settings.redis_namespace || 'umrdr_dev_of_some_kind'
+Rails.logger.info "Rescue namespace set to #{Resque.redis.namespace}"

--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -3,5 +3,7 @@ config = YAML.load(ERB.new(IO.read(File.join(Rails.root, 'config', 'redis.yml'))
 Resque.redis = Redis.new(host: config[:host], port: config[:port], thread_safe: true)
 
 Resque.inline = Rails.env.test?
+
 Resque.redis.namespace = ENV['REDIS_NS'] || 'umrdr_dev_of_some_kind'
-Rails.logger.info "Rescue namespace is #{Settings.resque_namespace}"
+Rails.logger.info "Rescue namespace is #{Resque.redis.namespace}"
+Rails.logger.info "Rescue REDIS_NS environment variable is #{ENV['REDIS_NS']}"

--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -3,5 +3,5 @@ config = YAML.load(ERB.new(IO.read(File.join(Rails.root, 'config', 'redis.yml'))
 Resque.redis = Redis.new(host: config[:host], port: config[:port], thread_safe: true)
 
 Resque.inline = Rails.env.test?
-Resque.redis.namespace = Settings.resque_namespace || 'umrdr_dev_of_some_kind'
+Resque.redis.namespace = ENV['REDIS_NS'] || 'umrdr_dev_of_some_kind'
 Rails.logger.info "Rescue namespace is #{Settings.resque_namespace}"

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -64,8 +64,7 @@ Sufia.config do |config|
   # config.translate_uri_to_id = ActiveFedora::Noid.config.translate_uri_to_id
   # config.translate_id_to_uri = ActiveFedora::Noid.config.translate_id_to_uri
 
-  # Specify the prefix for Redis keys:
-  config.redis_namespace = Settings.redis_namespace
+  # (resque namespace taken care of in upload/X-config/settings/X.yml)
 
   # Specify the path to the file characterization tool:
   config.fits_path = system("which", "fits.sh") ? "fits.sh" : "/l/local/fits/fits.sh"


### PR DESCRIPTION
Now pulls from settings, which in turn relies on the ENV variables
set by the systemd script.