### PR TITLE
Configure redis.namespace consistently

### DIFF
--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -3,4 +3,14 @@ config = YAML.load(ERB.new(IO.read(File.join(Rails.root, 'config', 'redis.yml'))
 Resque.redis = Redis.new(host: config[:host], port: config[:port], thread_safe: true)
 
 Resque.inline = Rails.env.test?
-#Resque.redis.namespace = "#{CurationConcerns.config.redis_namespace}:#{Rails.env}"
+
+# The redis_namespace should be being set in the umrdr-deploytment file
+# upload/XXX-config/settings/production.yml
+#
+# Both these need to be set, at least in our version of sufia. The former
+# is being used in one place...somewhere...while the latter is used
+# everywhere else.
+
+config.redis_namespace = Settings.redis_namespace || 'umrdr_stupid_unconfigured_namespace'
+Resque.redis.namespace = Settings.redis_namespace || 'umrdr_stupid_unconfigured_namespace'
+


### PR DESCRIPTION
Previous to this, we had problems with multple instantations of Hydra
using the same Resque/Redis setup running into each other due to
the use of a default namespace somewhere deep inside sufia.

This change sets both used values based on the settings. The Settings
value is configured in `upload/XXX-config/settings/production.yml`

Fixes #537