### PR TITLE
removed default icon from work page.

### DIFF
--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -8,7 +8,6 @@
 <% editor    = can?(:edit,    @presenter.id) %>
 
 <%= render 'recent_uploads', work: @presenter %>
-<%= render 'representative_media', presenter: @presenter %>
 <%= render 'attributes', presenter: @presenter %>
 <%= render 'related_files', presenter: @presenter %>
 

--- a/app/views/curation_concerns/file_sets/media_display/_default.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_default.html.erb
@@ -6,7 +6,7 @@
         </figure>
     <% end %>
 <% else %>
-    <figure>
-        <%= image_tag "default.png", alt: "No preview available", class: "img-responsive generic-icon" %>
-    </figure>
+   <figure>
+     <%= image_tag "default.png", alt: "No preview available", class: "img-responsive generic-icon" %>
+   </figure>
 <% end %>


### PR DESCRIPTION
Fixes #587 

The presence of the thumbnail on the work page is determined by a configuration parameter. Sufia.config.display_media_download_link

which is set to false, and so I just removed the default icon.  So if the config is set to false now, you should never see an icon on the work page.