### PR TITLE
Fixup/redis resque namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,8 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
-
+# will load new rubyzip version
+gem 'rubyzip', '>= 1.0.0'
 
 group :production do
   # Only try to run virus scan in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -756,6 +756,7 @@ DEPENDENCIES
   rsolr (~> 1.0.6)
   rspec-activemodel-mocks
   rspec-rails
+  rubyzip (>= 1.0.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   solr_wrapper (>= 0.3)

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ University of Michigan Library.
 ## License
 
 Regents of the University of Michigan... likely some rights reserved.
+
+## Wiki
+
+https://github.com/mlibrary/umrdr/wiki

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,3 +20,4 @@
 //= require uploader.js
 //= require date_coverage_field
 //= require more
+//= require draft_save

--- a/app/assets/javascripts/draft_save.js
+++ b/app/assets/javascripts/draft_save.js
@@ -1,0 +1,13 @@
+$(document).ready(function() {
+    
+$('#isDraft').click(function() {
+  if($(this).is(":checked")) {
+    $('#with_files_submit').val("Save as Draft");
+   }
+   else
+   {
+     $('#with_files_submit').val("Publish");
+    }       
+});
+
+});

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,7 +8,7 @@ class Ability
   self.ability_logic += [:umrdr_abilities]
 
   def umrdr_abilities
-    alias_action :identifiers, to: :update
+    alias_action :identifiers, :download, to: :update
   end
 
   # Define any customized permissions here.

--- a/app/presenters/umrdr/file_set_presenter.rb
+++ b/app/presenters/umrdr/file_set_presenter.rb
@@ -6,5 +6,10 @@ module Umrdr
   		g.doi.present?
     end
 
+    def parent_public?
+  		g =GenericWork.find (self.parent.id)
+  		g.public?
+    end
+
   end
 end

--- a/app/views/curation_concerns/base/_form.html.erb
+++ b/app/views/curation_concerns/base/_form.html.erb
@@ -12,7 +12,7 @@
     <% end %>
 
     <div class="primary-actions">
-      <%= f.submit 'Save', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+      <%= f.submit 'Publish', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
       <%= link_to t(:'helpers.action.cancel'), curation_concern.new_record? ? main_app.root_path : polymorphic_path([main_app, curation_concern]), class: 'btn btn-link' %>
     </div>
 

--- a/app/views/curation_concerns/base/_show_actions.html.erb
+++ b/app/views/curation_concerns/base/_show_actions.html.erb
@@ -8,7 +8,7 @@
   <% end %>
   
   <% if @presenter.editor? %>
-      <% if @presenter.identifiers_minted?(:doi) %>
+      <% if @presenter.identifiers_minted?(:doi) && @presenter.solr_document.public? %>
 
         <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]),  class: 'btn btn-default disabled' %>
         <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger disabled pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -8,7 +8,6 @@
 <% editor    = can?(:edit,    @presenter.id) %>
 
 <%= render 'recent_uploads', work: @presenter %>
-<%= render 'representative_media', presenter: @presenter %>
 <%= render 'attributes', presenter: @presenter %>
 <%= render 'related_files', presenter: @presenter %>
 

--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 
   <% if @presenter.editor? %>
-      <% unless @presenter.parent_doi? %> 
+      <% unless @presenter.parent_doi? && @presenter.parent_public? %> 
          <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]),
                      class: 'btn btn-default' %>
          <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter],

--- a/app/views/curation_concerns/file_sets/media_display/_default.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_default.html.erb
@@ -6,7 +6,7 @@
         </figure>
     <% end %>
 <% else %>
-    <figure>
-        <%= image_tag "default.png", alt: "No preview available", class: "img-responsive generic-icon" %>
-    </figure>
+   <figure>
+     <%= image_tag "default.png", alt: "No preview available", class: "img-responsive generic-icon" %>
+   </figure>
 <% end %>

--- a/app/views/curation_concerns/file_sets/upload/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/upload/_form.html.erb
@@ -1,16 +1,31 @@
 <% unless @presenter.identifiers_minted?(:doi) %>
+  <% if Sufia.config.download_files && @presenter.file_set_presenters.length > 1 %>
+    <%= form_tag(main_app.download_curation_concerns_generic_work_path(@presenter.id), method: 'post') do %>
+      <%= hidden_field_tag('generic_work[nop]') %>
+      <%= submit_tag(t('simple_form.actions.generic_work.download'), class: 'btn btn-primary') %>
+    <% end %>
+    <p></p>
+  <% end %>
+
   <div class="well">
     <%= form_for(FileSet.new, url: main_app.curation_concerns_file_sets_path(parent_id: @presenter.id), html: { multipart: true, id: 'fileupload' }) do |f| %>
       <%= render 'curation_concerns/file_sets/upload/form_fields', presenter: @presenter, upload_set_id: ActiveFedora::Noid::Service.new.mint %>
     <% end %>
 
-    <% editor    = can?(:edit,    @presenter.id) %>
-    <% if editor && @presenter.file_set_presenters.present? %>
-      <%= form_tag(main_app.identifiers_curation_concerns_generic_work_path(@presenter.id), method: 'post') do %>
-        <%= hidden_field_tag('generic_work[nop]') %>
-        <%= submit_tag(t('simple_form.actions.generic_work.mint_doi'), class: 'btn btn-primary') %>
-        <p class="alert alert-info">You can mint a DOI once you have uploaded all your files. Once a DOI is minted, you may not upload additional files, edit, or delete your work. For questions or help, please <strong><%= link_to "contact Deep Blue Data", "https://deepblue.lib.umich.edu/data/contact" %></strong>.</p>
+      <% editor    = can?(:edit,    @presenter.id) %>
+      <% if editor && @presenter.file_set_presenters.present? %>
+        <%= form_tag(main_app.identifiers_curation_concerns_generic_work_path(@presenter.id), method: 'post') do %>
+          <%= hidden_field_tag('generic_work[nop]') %>
+          <%= submit_tag(t('simple_form.actions.generic_work.mint_doi'), class: 'btn btn-primary') %>
+          <p class="alert alert-info">You can mint a DOI once you have uploaded all your files. Once a DOI is minted, you may not upload additional files, edit, or delete your work. For questions or help, please <strong><%= link_to "contact Deep Blue Data", "https://deepblue.lib.umich.edu/data/contact" %></strong>.</p>
+        <% end %>
       <% end %>
-    <% end %>
   </div>
+<% else %>
+  <% if Sufia.config.download_files && @presenter.file_set_presenters.length > 1 %>
+    <%= form_tag(main_app.download_curation_concerns_generic_work_path(@presenter.id), method: 'post') do %>
+      <%= hidden_field_tag('generic_work[nop]') %>
+      <%= submit_tag(t('simple_form.actions.generic_work.download'), class: 'btn btn-primary') %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/curation_concerns/file_sets/upload/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/upload/_form.html.erb
@@ -1,4 +1,4 @@
-<% unless @presenter.identifiers_minted?(:doi) %>
+<% unless @presenter.identifiers_minted?(:doi) && @presenter.solr_document.public? %>
   <% if Sufia.config.download_files && @presenter.file_set_presenters.length > 1 %>
     <%= form_tag(main_app.download_curation_concerns_generic_work_path(@presenter.id), method: 'post') do %>
       <%= hidden_field_tag('generic_work[nop]') %>
@@ -12,14 +12,14 @@
       <%= render 'curation_concerns/file_sets/upload/form_fields', presenter: @presenter, upload_set_id: ActiveFedora::Noid::Service.new.mint %>
     <% end %>
 
-      <% editor    = can?(:edit,    @presenter.id) %>
-      <% if editor && @presenter.file_set_presenters.present? %>
-        <%= form_tag(main_app.identifiers_curation_concerns_generic_work_path(@presenter.id), method: 'post') do %>
-          <%= hidden_field_tag('generic_work[nop]') %>
-          <%= submit_tag(t('simple_form.actions.generic_work.mint_doi'), class: 'btn btn-primary') %>
-          <p class="alert alert-info">You can mint a DOI once you have uploaded all your files. Once a DOI is minted, you may not upload additional files, edit, or delete your work. For questions or help, please <strong><%= link_to "contact Deep Blue Data", "https://deepblue.lib.umich.edu/data/contact" %></strong>.</p>
-        <% end %>
+    <% editor    = can?(:edit,    @presenter.id) %>
+    <% if editor && @presenter.file_set_presenters.present? && !@presenter.identifiers_minted?(:doi) %>
+      <%= form_tag(main_app.identifiers_curation_concerns_generic_work_path(@presenter.id), method: 'post') do %>
+        <%= hidden_field_tag('generic_work[nop]') %>
+        <%= submit_tag(t('simple_form.actions.generic_work.mint_doi'), class: 'btn btn-primary') %>
+        <p class="alert alert-info">You can mint a DOI once you have uploaded all your files. Once a DOI is minted, you may not upload additional files, edit, or delete your work. For questions or help, please <strong><%= link_to "contact Deep Blue Data", "https://deepblue.lib.umich.edu/data/contact" %></strong>.</p>
       <% end %>
+    <% end %>
   </div>
 <% else %>
   <% if Sufia.config.download_files && @presenter.file_set_presenters.length > 1 %>

--- a/app/views/records/edit_fields/_visibility.html.erb
+++ b/app/views/records/edit_fields/_visibility.html.erb
@@ -1,20 +1,17 @@
  <p><label>
  <% if (curation_concern.visibility ==Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE && curation_concern.date_uploaded ==nil)%> 
-  <%= check_box_tag 'isDraft', Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, false %>  Draft
-  <p>All non-draft works are publicly viewable after being saved. Select draft to save your work without making it public.</p>
+  <%= check_box_tag 'isDraft', Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, false %>  Save as Draft
 <% elsif (curation_concern.visibility==Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
-   <%= check_box_tag 'isDraft', Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, true %>   Draft
-   <p>All non-draft works are publicly viewable after being saved. Select draft to save your work without making it public.</p>
+   <%= check_box_tag 'isDraft', Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, true %>   Save as Draft
 <% elsif (curation_concern.visibility !=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)%> 
-   <%= check_box_tag 'isDraft', Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, false %>   Draft
-   <p>All non-draft works are publicly viewable after being saved. Select draft to save your work without making it public.</p>
+   <%= check_box_tag 'isDraft', Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, false %>   Save as Draft
 <% end %>
 </label>
 </p>
-<p>Select Save and add files on the next page.</p>
 
-	
-
+<p>If you select Save as Draft, your work will not be published yet and you can make changes to the work.</p>
+<p>If you do not select Save as Draft, your work will be published after adding files to your work. It will be openly accessible and you cannot make changes to the work. </p>
+<p>Proceed to the next page to add files.</p>
 
 
 

--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -13,7 +13,7 @@
 
 <p>The datasets that underlie research findings are increasingly in demand. Funding agencies require that research data be discoverable, accessible and preserved for future use. Publishers ask for data sets to be included alongside of publications as supplemental files to support research findings. Researchers seek out existing data sets to test out new theories or generate new discoveries.</p>
 
-<p>In response, The University of Michigan Library has developed Deep Blue Data, a repository service for sharing and archiving research data developed at the University of Michigan. Deep Blue Data is a component of a suite of services provided by the U-M Library designed to preserve and provide access to the intellectual contributions in research, teaching and creativity made by the University of Michigan community and to ensure its longevity.</p>
+<p>In response, The University of Michigan Library has developed Deep Blue Data, a repository for sharing and archiving research data that were developed at the University of Michigan. Deep Blue Data is a component of a suite of services provided by the U-M Library designed to broadly disseminate the intellectual contributions in research, teaching and creativity made by the University of Michigan community and to ensure its longevity.</p>
 
 <h3 id="why-deposit-in-deep-blue-data">Why deposit in Deep Blue Data?</h3>
 
@@ -21,13 +21,13 @@
 
 <p><strong>Compliance with grant requirements</strong> &mdash; Depositing your data into Deep Blue Data enables you to demonstrate compliance with funding agency requirements to share and archive your data sets.</p>
 
-<p><strong>Get credit for your work</strong> &mdash; Your data will be assigned a Digital Object Identifier upon deposit making it easier for people to cite your data set and provide proper attribution. </p>
+<p><strong>Get credit for your work</strong> &mdash; You can assign a Digital Object Identifier to your work upon deposit making it easier for people to cite your data set and provide proper attribution.</p>
 
 <p><strong>Preserve your data</strong> &mdash; The University of Michigan Library is committed to preserving the data sets deposited into Deep Blue Data. See <a href="<%= static_path('file-format-preservation') %>">File formats and Preservation</a> for details.</p>
 
 <p><strong>It&apos;s Free</strong> &mdash; There is no charge to deposit data into the Deep Blue Data repository in most cases.</p>
 
-<p><strong>Local Assistance</strong> &mdash; Have questions about depositing data into Deep Blue Data? Need some advice on how to prepare your data for deposit? <a href="<%= sufia.contact_path %>">Contact Us</a>.</p>
+<p><strong>Local Assistance</strong> &mdash; Librarians can meet with you to help guide you in preparing your data set for deposit  into Deep Blue Data. <a href="<%= sufia.contact_path %>">Contact Us</a> to set up a consultation.</p>
 
 <h3 id="who-can-deposit">Who can deposit?</h3>
 <p><strong>We welcome deposits from:</strong></p>
@@ -41,7 +41,7 @@
 <h3 id="what-kinds-of-data-are-accepted">What kinds of data are accepted?</h3>
 <p><strong>We accept:</strong></p>
 <ul>
-  <li>Data from all disciplines.</li>
+  <li>Research data from all disciplines.</li>
   <li>Data in formats that are open and nonproprietary.</li>
   <li>Data in proprietary formats that are widely used and appropriate for the research communities likely to have interest in the data.</li>
 </ul>
@@ -50,20 +50,19 @@
 
 <p><strong>We cannot accept:</strong></p>
 <ul>
-  <li>Data under the purview of <a href="http://research-compliance.umich.edu/">U-M Research Compliance Programs</a> that are subject to export controls, present a conflict of interest for the University or the Researcher(s), or whose distribution would otherwise constitute a violation of research ethics or compliance.</li>
+  <li>Data on human subjects or sensitive data under the purview of <a href="http://research-compliance.umich.edu/">U-M Research Compliance Programs</a>. This includes data that are subject to export controls, present a conflict of interest for the University or the Researcher(s), or whose distribution would otherwise constitute a violation of research ethics or compliance.</li>
   <li>Data containing personally identifiable information that would prohibit public access.</li>
-  <li>Administrative data, unless being used for research purposes and with the prior consent and agreement of the U-M Library. </li>
-  <li>Sensitive data.</li>
+  <li>Administrative data, unless being used for research purposes and with the prior consent and agreement of the U-M Library.</li>
+  <li>Data that is encrypted.</li>
 </ul>
 
 <p><a href="<%= static_path('agreement') %>">Review our policy and terms of use for more details</a></p>
 
 <h3 id="what-are-the-other-requirements">What are the other requirements for depositing data?</h3>
 <ul>
-  <li>Our intent is to make data as openly available as possible for discovery, understanding, and reuse.</li>
+  <li>Data in Deep Blue Data are openly available to anyone. Therefore, submitted data must be ready for distribution and reuse by others.</li>
   <li>Data submitted should be complete.</li>
-  <li>Data must be ready for distribution and re-use by others.</li>
-  <li>Deposit must include appropriate descriptive metadata.</li>
+  <li>Deposit must include appropriate documentation and descriptive metadata.</li>
   <li>The depositor must agree to the <a href="<%= static_path('agreement') %>">Deep Blue Data terms of use</a>, which affirms the deposit is original work and does not infringe on the rights of others.</li>
 </ul>
 

--- a/app/views/sufia/homepage/_featured.html.erb
+++ b/app/views/sufia/homepage/_featured.html.erb
@@ -7,11 +7,10 @@
   <div class="featured-work-info">
 
     <%
-      profile  = link_to_profile presenter.depositor('')
       keywords = link_to_facet_list(presenter.keyword, 'keyword', '')
     %>
-    <% unless profile.empty? %>
-      <p><strong>Deposited by:</strong> <%= profile %></p>
+    <% unless presenter.depositor.empty? %>
+      <p><strong>Deposited by:</strong> <%= presenter.depositor('') %></p>
     <% end %>
     <% unless keywords.empty? %>
       <p><strong>Keywords:</strong> <%= keywords %></p>

--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -11,6 +11,6 @@ Resque.inline = Rails.env.test?
 # is being used in one place...somewhere...while the latter is used
 # everywhere else.
 
-Sufia.config.redis_namespace = Settings.redis_namespace || 'umrdr_stupid_unconfigured_namespace'
-Resque.redis.namespace = Settings.redis_namespace || 'umrdr_stupid_unconfigured_namespace'
+Sufia.config.redis_namespace = Settings.redis_namespace || 'umrdr_redis_namespace_needs_configuration'
+Resque.redis.namespace = Settings.redis_namespace       || 'umrdr_redis_namespace_needs_configuration'
 

--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -11,6 +11,6 @@ Resque.inline = Rails.env.test?
 # is being used in one place...somewhere...while the latter is used
 # everywhere else.
 
-config.redis_namespace = Settings.redis_namespace || 'umrdr_stupid_unconfigured_namespace'
+Sufia.config.redis_namespace = Settings.redis_namespace || 'umrdr_stupid_unconfigured_namespace'
 Resque.redis.namespace = Settings.redis_namespace || 'umrdr_stupid_unconfigured_namespace'
 

--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -3,4 +3,14 @@ config = YAML.load(ERB.new(IO.read(File.join(Rails.root, 'config', 'redis.yml'))
 Resque.redis = Redis.new(host: config[:host], port: config[:port], thread_safe: true)
 
 Resque.inline = Rails.env.test?
-#Resque.redis.namespace = "#{CurationConcerns.config.redis_namespace}:#{Rails.env}"
+
+# The redis_namespace should be being set in the umrdr-deploytment file
+# upload/XXX-config/settings/production.yml
+#
+# Both these need to be set, at least in our version of sufia. The former
+# is being used in one place...somewhere...while the latter is used
+# everywhere else.
+
+config.redis_namespace = Settings.redis_namespace || 'umrdr_stupid_unconfigured_namespace'
+Resque.redis.namespace = Settings.redis_namespace || 'umrdr_stupid_unconfigured_namespace'
+

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -82,6 +82,11 @@ Sufia.config do |config|
   
   config.geonames_username = ''
 
+  #This enables or disables the ability to download files.
+  config.define_singleton_method(:download_files) do
+    return true
+  end
+
   #config.max_file_size = 2 * ( 1024 ** 3 )
   #config.max_file_size_str = ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert(config.max_file_size, {})
 

--- a/config/locales/umrdr.en.yml
+++ b/config/locales/umrdr.en.yml
@@ -135,6 +135,7 @@ en:
     actions:
       generic_work:
         mint_doi: "Mint DOI"
+        download: "Download All Files"
     # TODO: Consolidate/clean up remove/add difference.
     #  such that it can be under the add_remove_labels.
         remove:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,10 +25,11 @@ Rails.application.routes.draw do
   curation_concerns_embargo_management
   concern :exportable, Blacklight::Routes::Exportable.new
 
-  namespace :curation_concerns, path: :concern do
+  namespace :curation_concerns,  path: :concern do
     resources :generic_works do
       member do
         post 'identifiers'
+        post 'download'
       end
     end
   end

--- a/lib/tasks/populate_dev_app.rake
+++ b/lib/tasks/populate_dev_app.rake
@@ -1,5 +1,6 @@
 require 'yaml'
 require_relative '../build_content_service'
+require_relative '../append_content_service'
 
 namespace :umrdr do
 
@@ -11,6 +12,16 @@ namespace :umrdr do
 
     puts "Done."
   end
+
+  desc "Append files to existing collections."
+  task :append, [:path_to_config] => :environment do |t, args|
+    ENV["RAILS_ENV"] ||= "development"
+
+    args.one? ? config_setup_for_append(args[:path_to_config]) : demo_setup
+
+    puts "Done."
+  end
+
 end
 
 def config_setup(path_to_config)
@@ -18,8 +29,15 @@ def config_setup(path_to_config)
     puts "bad path to config" 
     return
   end
-  
   BuildContentService.call(path_to_config)
+end
+
+def config_setup_for_append(path_to_config)
+  unless File.exist? path_to_config
+    puts "bad path to config" 
+    return
+  end
+  AppendContentService.call(path_to_config)
 end
 
 def demo_setup


### PR DESCRIPTION
Previous to this, we had problems with multiple instantations of Hydra
using the same Resque/Redis setup running into each other due to
the use of a default namespace somewhere deep inside sufia.

This change sets both used values based on the settings. The Settings
value is configured in upload/XXX-config/settings/production.yml

Fixes #537