### PR TITLE
Configure redis.namespace consistently

### DIFF
--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -4,3 +4,6 @@ Resque.redis = Redis.new(host: config[:host], port: config[:port], thread_safe: 
 
 Resque.inline = Rails.env.test?
 #Resque.redis.namespace = "#{CurationConcerns.config.redis_namespace}:#{Rails.env}"
+
+Sufia.config.redis_namespace = Settings.redis_namespace || 'umrdr_redis_namespace_needs_configuration'
+Resque.redis.namespace = Settings.redis_namespace       || 'umrdr_redis_namespace_needs_configuration'


### PR DESCRIPTION
Previous to this, we had problems with multple instantations of Hydra
using the same Resque/Redis setup running into each other due to
the use of a default namespace somewhere deep inside sufia.

This change sets both used values based on the settings. The Settings
value is configured in `upload/XXX-config/settings/production.yml`

Fixes #537