### PR TITLE
Fix #597 - Do not preserve file modes for TinyMCE assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,5 @@ gem 'rsolr', '~> 1.0.6'
 gem 'devise'
 gem 'devise-guests', '~> 0.3'
 
+# Temporary Github dependency to work with our deployment (needs pull request #77, > 4.0.17.beta)
+gem 'tinymce-rails-imageupload', git: 'https://github.com/PerfectlyNormal/tinymce-rails-imageupload.git', ref: '230416b793ad89df3618eee9c61770d652ff86d7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/PerfectlyNormal/tinymce-rails-imageupload.git
+  revision: 230416b793ad89df3618eee9c61770d652ff86d7
+  ref: 230416b793ad89df3618eee9c61770d652ff86d7
+  specs:
+    tinymce-rails-imageupload (4.0.17.beta)
+      railties (>= 3.2, < 6)
+      tinymce-rails (~> 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -683,9 +692,6 @@ GEM
     tilt (2.0.5)
     tinymce-rails (4.4.1)
       railties (>= 3.1.1)
-    tinymce-rails-imageupload (4.0.17.beta)
-      railties (>= 3.2, < 6)
-      tinymce-rails (~> 4.0)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
@@ -762,9 +768,10 @@ DEPENDENCIES
   solr_wrapper (>= 0.3)
   sqlite3
   sufia (~> 7.0)
+  tinymce-rails-imageupload!
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.13.6
+   1.14.2

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,5 +52,15 @@ module Umrdr
 
     # Additional directories with ruby to be autoloaded
     config.autoload_paths += Dir["#{config.root}/lib/**/*"]
+
+    require 'tinymce/rails/asset_installer/copy'
+    class CopyNoPreserve < TinyMCE::Rails::AssetInstaller::Copy
+      def copy_assets
+        logger.info "Copying assets (without mode preservation) to #{File.join(target, "tinymce")}"
+        FileUtils.cp_r(assets, target)
+      end
+    end
+
+    config.tinymce.install = CopyNoPreserve
   end
 end


### PR DESCRIPTION
There is config option for the TinyMCE asset installer where you can
supply a strategy. The default "Copy" strategy preserves file
attributes, but otherwise seems fine.

This change subclasses and overrides just the `copy_assets` method with
all the same behavior except that it does not attempt to preserve.