### PR TITLE
#597 - Upgrade tinymce imageupload gem for deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,4 +76,5 @@ end
 gem 'rsolr', '~> 1.0.6'
 gem 'devise'
 gem 'devise-guests', '~> 0.3'
+gem 'tinymce-rails-imageupload', '~> 4.0.17.beta.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -683,7 +683,7 @@ GEM
     tilt (2.0.5)
     tinymce-rails (4.4.1)
       railties (>= 3.1.1)
-    tinymce-rails-imageupload (4.0.17.beta)
+    tinymce-rails-imageupload (4.0.17.beta.2)
       railties (>= 3.2, < 6)
       tinymce-rails (~> 4.0)
     turbolinks (5.0.1)
@@ -762,9 +762,10 @@ DEPENDENCIES
   solr_wrapper (>= 0.3)
   sqlite3
   sufia (~> 7.0)
+  tinymce-rails-imageupload (~> 4.0.17.beta.2)
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.13.6
+   1.14.2


### PR DESCRIPTION
This upgrades the imageupload gem to use the custom install strategy (non-preserving copy), which should take care of the last permissions difficulty in deployment.