### PR TITLE
remove the file just ingested in the create derivatives job.

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -41,10 +41,8 @@ module Hyrax
       logger.error "FileSetController::create rescued #{error.class}\n\t#{error}\n #{error.backtrace.join("\n")}\n\n"
       render_json_response(response_type: :internal_error, options: { message: 'Error occurred while creating a FileSet.' })
     ensure
-      # remove the tempfile (only if it is a temp file)
-      #because file is getting delete. sikekiq
-      #just comment this out becuae of hyrax upgrade. sidekiq was what I was trying.
-
+      #We used to remove the file here, but we were seeing that the file was not being uploaded when doing asynchronous 
+      #ingestion.  So  now this is done in create_derivatives_job.rb ( this is the last step in the process )
       #file.tempfile.delete if file.respond_to?(:tempfile)
     end
 

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -1,0 +1,32 @@
+class CreateDerivativesJob < ActiveJob::Base
+  queue_as Hyrax.config.ingest_queue_name
+
+  # @param [FileSet] file_set
+  # @param [String] file_id identifier for a Hydra::PCDM::File
+  # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
+  def perform(file_set, file_id, filepath = nil)
+    return if file_set.video? && !Hyrax.config.enable_ffmpeg
+    filename = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
+
+    file_set.create_derivatives(filename)
+
+    # Reload from Fedora and reindex for thumbnail and extracted text
+    file_set.reload
+    file_set.update_index
+    file_set.parent.update_index if parent_needs_reindex?(file_set)
+
+    #This is the last step in the process ( ingest job -> characterization job -> create derivative (last step))
+    #So now it's safe to remove the file uploaded file.
+    if File.exist?(filepath)
+      File.delete (filepath)
+    end
+
+  end
+
+  # If this file_set is the thumbnail for the parent work,
+  # then the parent also needs to be reindexed.
+  def parent_needs_reindex?(file_set)
+    return false unless file_set.parent
+    file_set.parent.thumbnail_id == file_set.id
+  end
+end


### PR DESCRIPTION
We were seeing that when a file is uploaded it was not being removed from the temp area.  This was because the ingestion was being done asynchronously, so this change will delete the temp file when it created the derivative.  When ingesting a file, the system sends it through some jobs:

Ingest Job -> Characterizing Job -> Create Derivative Job

So when the last job is completed, it can then delete the temp file.

This Fixes #651 