### PR TITLE
start of tweaking to make admin area usable

### DIFF
--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,3 +1,4 @@
+<% unless request.path.index('/admin') %>
 <div id="masthead" class="container-fluid">
   <div class="row ribbon-content">
     <div class="col-xs-12 col-sm-8 site-brand-wrap">
@@ -8,3 +9,4 @@
     </div>
   </div>
 </div>
+<% end %>

--- a/config/role_map.yml
+++ b/config/role_map.yml
@@ -4,6 +4,7 @@ development:
   admin:
     - njaffer@umich.edu
     - blancoj@umich.edu
+    - roger@umich.edu
 test:
   archivist:
     - archivist1@example.com


### PR DESCRIPTION
Ignore the masthead for `/admin` paths; updated roles_map.yml.