### PR TITLE
nix relative_url_root under test ... because?

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module Umrdr
     config.max_total_file_size_str = ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert(config.max_total_file_size, {})
 
     # Deploy to /data instead of /
-    config.relative_url_root = '/data'
+    config.relative_url_root = '/data' unless Rails.env.test?
 
     # For properly generating URLs and minting DOIs - the app may not by default
     # Outside of a request context the hostname needs to be provided.

--- a/spec/features/create_generic_work_spec.rb
+++ b/spec/features/create_generic_work_spec.rb
@@ -17,10 +17,16 @@ RSpec.feature 'Create a GenericWork' do
     end
 
     scenario do
-      visit new_curation_concerns_generic_work_path
+      visit new_hyrax_generic_work_path
       fill_in 'Title', with: 'Test GenericWork'
-      click_button 'Create GenericWork'
+      fill_in 'Creator', with: 'Creator, Test'
+      fill_in 'Method', with: 'Test'
+      fill_in 'Description', with: 'Test'
+      choose 'generic_work_rights_httpcreativecommonsorgpublicdomainzero10'
+      select 'Other', from: 'generic_work_subject'
+      click_button 'Publish'
       expect(page).to have_content 'Test GenericWork'
+      expect(page).to have_content 'Creator, Test'
     end
   end
 end


### PR DESCRIPTION
- does capybara work with `relative_url_root`? Does not seem to. Disabling it makes the feature set pass
- updated create_generic_work_spec for hydra (and required fields)