### PR TITLE
When not a true admin set is displayed on the admin_sets page, put ou…

### DIFF
--- a/app/views/hyrax/admin/admin_sets/index.html.erb
+++ b/app/views/hyrax/admin/admin_sets/index.html.erb
@@ -1,0 +1,48 @@
+<% content_for :page_header do %>
+  <h1><span class="fa fa-sitemap"></span> Administrative Sets</h1>
+  <div class="pull-right">
+    <%= link_to hyrax.new_admin_admin_set_path, class: 'btn btn-primary' do %>
+      <span class="fa fa-edit"></span> <%= t(:'helpers.action.admin_set.new') %>
+    <% end %>
+  </div>
+<% end %>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+    <% if @admin_sets.present? %>
+      <div class="table-responsive">
+        <table class="table table-striped datatable">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Date created</th>
+              <th>Creator</th>
+              <th>Works</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @admin_sets.each do |admin_set| %>
+              <tr>
+                <% begin %>
+                  <% link_to admin_set.title.first, [hyrax, :admin, admin_set]  %>
+                <% rescue %>
+                  <td>Something went wrong trying to get admin set link. Perhaps not a true admin set.<td>
+                <% else %>
+                  <td><%= link_to admin_set.title.first, [hyrax, :admin, admin_set] %></td>
+                <% end %>
+                <td><%= admin_set.create_date %></td>
+                <td><%= safe_join(admin_set.creator) %></td>
+                <td><%= controller.presenter_class.new(admin_set, current_ability).total_items %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <% else %>
+        <p>No administrative sets have been created.</p>
+        <%= link_to hyrax.new_admin_admin_set_path, class: 'btn btn-primary' do %>
+          <span class="fa fa-edit"></span> <%= t(:'helpers.action.admin_set.new') %>
+        <% end %>
+      <% end %>
+  </div>
+</div>


### PR DESCRIPTION
This Fixes #684 

So now if you are in the admin/admin_sets and there is an error message, and error message is displayed.