### PR TITLE
enable fulltext search.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -41,7 +41,7 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "title_tesim name_tesim"
+      qf: "title_tesim name_tesim all_text_timv"
     }
 
     # Specify which field to use in the tag cloud on the homepage.


### PR DESCRIPTION
With this setting when user enters something in the input box to search, it will search the full text.  Fixes #642 