### PR TITLE
catch Ldp:Gone error that happens if there are no Derivatives

### DIFF
--- a/config/initializers/file_set_derivatives_service.rb
+++ b/config/initializers/file_set_derivatives_service.rb
@@ -1,0 +1,11 @@
+Hyrax::FileSetDerivativesService.class_eval do
+
+  def valid?
+    begin
+      supported_mime_types.include?(mime_type)
+    rescue
+      nil
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes #688