### PR TITLE
Umrdr 727 remove access link

### DIFF
--- a/app/views/hyrax/my/_index_partials/_list_collections.html.erb
+++ b/app/views/hyrax/my/_index_partials/_list_collections.html.erb
@@ -1,0 +1,44 @@
+<% id = document.id %>
+<tr id="document_<%= id %>">
+  <td></td>
+  <td>
+    <div class="media">
+      <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-small pull-left"></span>
+      <div class="media-body">
+        <div class="media-heading">
+          <%= link_to url_for_document(document), id: "src_copy_link#{id}" do %>
+              <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %> </span>
+              <%= document.title_or_label %>
+          <% end %>
+          <a href="#" class="small" title="Click for more details">
+            <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>
+            <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{document.title_or_label}" %></span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </td>
+  <td class="text-center"><%= document.create_date %> </td>
+  <td class="text-center">
+    <%= visibility_badge(document.visibility) %>
+  </td>
+  <td class="text-center">
+    <%= render 'collection_action_menu', id: id %>
+   </td>
+</tr>
+<tr id="detail_<%= id %>"> <!--  collection detail"> -->
+  <td colspan="6">
+    <dl class="expanded-details row">
+      <dt class="col-xs-3 col-lg-2"><%= t("hyrax.dashboard.my.collection_list.description") %></dt>
+      <dd class="col-xs-9 col-lg-10"><%= document.description.first %></dd>
+      <dt class="col-xs-3 col-lg-2"><%= t("hyrax.dashboard.my.collection_list.edit_access") %></dt>
+      <dd class="col-xs-9 col-lg-10">
+      <% if document.edit_groups.present? %>
+        <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= document.edit_groups.join(', ') %>
+        <br/>
+      <% end %>
+        <%= t("hyrax.dashboard.my.collection_list.users") %> <%= document.edit_people.join(', ') %>
+      </dd>
+    </dl>
+  </td>
+</tr>

--- a/app/views/hyrax/my/_index_partials/_list_works.html.erb
+++ b/app/views/hyrax/my/_index_partials/_list_works.html.erb
@@ -1,0 +1,39 @@
+<tr id="document_<%= document.id %>">
+
+  <td>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%=t("hyrax.dashboard.my.sr.batch_checkbox")%></label>
+    <%= render '/batch_select/add_button', document: document %>&nbsp;
+  </td>
+
+  <td>
+    <div class='media'>
+      <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+      <% end %>
+
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
+            <span class="sr-only">
+              <%= t("hyrax.dashboard.my.sr.show_label") %>
+            </span>
+            <%= document.title_or_label %>
+          <% end %>
+
+          <br />
+          <%= render_collection_links(document) %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class='text-center'><%= document.date_uploaded %></td>
+  <td class='workflow-state'><%= presenter.workflow.state_label %></td>
+  <td class='text-center'><%= visibility_badge(document.visibility) %></td>
+
+  <td class='text-center'>
+    <%= render 'work_action_menu', document: document %>
+  </td>
+</tr>


### PR DESCRIPTION
This pull request adds two partials to override partials used to render table rows in the "My Works" and "My Collections" pages.  The new partials are exact copies of partials in [https://github.com/samvera/hyrax/tree/1-0-stable/app/views/hyrax/my/_index_partials](https://github.com/samvera/hyrax/tree/1-0-stable/app/views/hyrax/my/_index_partials) except that instead of calling the [AbilityHelper](https://github.com/samvera/hyrax/blob/1-0-stable/app/helpers/hyrax/ability_helper.rb)'s render_visibility_link method, they simply render the appropriate visibility badge.