### PR TITLE
in migration, don't validate when saving.

### DIFF
--- a/lib/hyrax/collections_migration.rb
+++ b/lib/hyrax/collections_migration.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  class CollectionsMigration
+    def self.run
+      ::Collection.all.each do |collection|
+        collection.members.each do |member|
+          member.member_of_collections << collection
+          unless member.save (validate: false)
+            raise "Work #{member.id} failed to save after recording its membership in collection #{collection.id}"
+          end
+        end
+        collection.members = []
+        unless collection.save (validate: false)
+          raise "Collection #{collection.id} failed to save after emptying its member list"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
so we can save without validation, since validation fails in our environment.