### PR TITLE
Resolves #807 'Clean up of About page'.

### DIFF
--- a/app/views/hyrax/static/_about_sidebar.html.erb
+++ b/app/views/hyrax/static/_about_sidebar.html.erb
@@ -1,0 +1,11 @@
+<% content_for :sidebar do %>
+<aside class="sidebar">
+  <h2>About</h2>
+  <ul>
+    <%= render partial: 'help_sidebar_link', locals: { path: 'about', label: "About Deep Blue Data" } %>
+    <%= render partial: 'help_sidebar_link', locals: { path: 'file-format-preservation', label: "File Formats & Preservation" } %>
+    <%= render partial: 'help_sidebar_link', locals: { path: 'retention', label: "Retention" } %>
+    <%= render partial: 'help_sidebar_link', locals: { path: 'support-for-depositors', label: "Support for Depositors" } %>
+  </ul>
+</aside>
+<% end %>

--- a/app/views/hyrax/static/_help_sidebar_link.erb
+++ b/app/views/hyrax/static/_help_sidebar_link.erb
@@ -1,3 +1,4 @@
+<!-- This is used by both the About sidebar and the Help sidebar. -->
     <li class="<%= action_name == path ? 'current' : '' %>">
         <%= link_to label, path %>
         <% if action_name == path and content_for?(:page_navigation) %><%= yield :page_navigation %><% end %>

--- a/app/views/hyrax/static/about.html.erb
+++ b/app/views/hyrax/static/about.html.erb
@@ -7,7 +7,7 @@
   <li><a href="#ready-to-get-started">Ready to get started?</a></li>
 </ul>
 <% end %>
-<%= render partial: 'help_sidebar' %>
+<%= render partial: 'about_sidebar' %>
 
 <h2>About Deep Blue Data</h2>
 

--- a/app/views/hyrax/static/file-format-preservation.html.erb
+++ b/app/views/hyrax/static/file-format-preservation.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'help_sidebar' %>
+<%= render partial: 'about_sidebar' %>
 <h2>File Formats &amp; Preservation</h2>
 
 <p>Deep Blue Data will accept any file format. All content will be stored on an enterprise-grade infrastructure with appropriate disaster recovery capabilities, security, and media replacement schedules.</p>

--- a/app/views/hyrax/static/retention.html.erb
+++ b/app/views/hyrax/static/retention.html.erb
@@ -5,7 +5,7 @@
     <li><a href="#copyright-and-take-down-notifications">Copyright and Take-Down Notifications</a></li>
 </ul>
 <% end %>
-<%= render partial: 'help_sidebar' %>
+<%= render partial: 'about_sidebar' %>
 <h2>Retention</h2>
 
 <h3 id="retention-review">Retention Review</h3>

--- a/app/views/hyrax/static/support-for-depositors.html.erb
+++ b/app/views/hyrax/static/support-for-depositors.html.erb
@@ -6,7 +6,7 @@
     <li><a href="#depositing">Depositing</a></li>
 </ul>
 <% end %>
-<%= render partial: 'help_sidebar' %>
+<%= render partial: 'about_sidebar' %>
 <h2>Support for Depositors</h2>
 
 <p><a href="http://www.lib.umich.edu/research-data-services">Research Data Services</a> and other members of the U-M Library provide a suite of services to assist you in preparing your data for deposit into Deep Blue Data.</p>


### PR DESCRIPTION
Trims down the About page to the four sidebar items specified in #807 and begins to decouple About and Help pages in anticipation of #808 which is up next.