### PR TITLE
Fixes #824 problem with Contact Us link in About page text.

### DIFF
--- a/app/views/hyrax/static/about.html.erb
+++ b/app/views/hyrax/static/about.html.erb
@@ -27,7 +27,7 @@
 
 <p><strong>It&apos;s Free</strong> &mdash; There is no charge to deposit data into the Deep Blue Data repository in most cases.</p>
 
-<p><strong>Local Assistance</strong> &mdash; Librarians can meet with you to help guide you in preparing your data set for deposit  into Deep Blue Data. <a href="hyrax.contact_path">Contact Us</a> to set up a consultation.</p>
+<p><strong>Local Assistance</strong> &mdash; Librarians can meet with you to help guide you in preparing your data set for deposit  into Deep Blue Data. <a href="<%= hyrax.contact_path %>">Contact Us</a> to set up a consultation.</p>
 
 <h3 id="who-can-deposit">Who can deposit?</h3>
 <p><strong>We welcome deposits from:</strong></p>


### PR DESCRIPTION
Enclose `hyrax.contact_path` in the correct `<%= … %>` inlining.