### PR TITLE
Hyrax branch: Use ClamAV Daemon instead of clamav

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,10 +54,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # will load new rubyzip version
 gem 'rubyzip', '>=1.0.0'
 
-group :production do
-  # Only try to run virus scan in production
-  gem 'clamav-client'
-end
+gem 'clamav-client'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'rubyzip', '>=1.0.0'
 
 group :production do
   # Only try to run virus scan in production
-  gem 'clamav'
+  gem 'clamav-client'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
-    clamav (0.4.1)
+    clamav-client (3.1.0)
     clipboard-rails (1.6.1)
     cliver (0.3.2)
     coderay (1.1.1)
@@ -716,7 +716,7 @@ DEPENDENCIES
   binding_of_caller
   blacklight_advanced_search (~> 6.0)
   capybara
-  clamav
+  clamav-client
   coffee-rails (~> 4.1.0)
   config
   database_cleaner

--- a/config/initializers/clamav.rb
+++ b/config/initializers/clamav.rb
@@ -1,4 +1,11 @@
 if defined? ClamAV and !(ENV['CI'] == 'true')
-  ClamAV.instance.loaddb
-  ClamAV.instance.setstring(ClamAV::CL_ENGINE_TMPDIR, File.join(Rails.root, 'tmp/derivatives'))
+  require "umich_clamav_daemon_scanner"
+  c = UMichClamAVDaemonScanner.new("this would be a filename")
+  if c.alive?
+    Hydra::Works.default_system_virus_scanner = UMichClamAVDaemonScanner
+    Rails.logger.info "Successfully connected to ClamAV Daemon"
+  else
+    Rails.logger.warn "Can't connect to ClamAV Daemon; skipping virus checks"
+  end
+  
 end

--- a/config/initializers/clamav.rb
+++ b/config/initializers/clamav.rb
@@ -1,11 +1,7 @@
 if defined? ClamAV and !(ENV['CI'] == 'true')
   require "umich_clamav_daemon_scanner"
-  c = UMichClamAVDaemonScanner.new("this would be a filename")
-  if c.alive?
-    Hydra::Works.default_system_virus_scanner = UMichClamAVDaemonScanner
-    Rails.logger.info "Successfully connected to ClamAV Daemon"
-  else
-    Rails.logger.warn "Can't connect to ClamAV Daemon; skipping virus checks"
-  end
-  
+  Hydra::Works.default_system_virus_scanner = UMichClamAVDaemonScanner
+  Rails.logger.info "Using ClamAV Daemon"
+else
+  Rails.logger.warn "No virus check in use."
 end

--- a/lib/umich_clamav_daemon_scanner.rb
+++ b/lib/umich_clamav_daemon_scanner.rb
@@ -26,6 +26,10 @@ class UMichClamAVDaemonScanner < Hydra::Works::VirusScanner
   # Reports `true` if a virus is found, `false` for all other
   # states (no virus or some sort of error)
   def infected?
+    unless alive?
+      warning "Cannot connect to virus scanner. Skipping"
+      return false
+    end
     file_io = File.open(file, 'rb')
     resp    = scan(file_io)
     case resp
@@ -37,10 +41,10 @@ class UMichClamAVDaemonScanner < Hydra::Works::VirusScanner
       true
     when ClamAV::ErrorResponse
       warn "ClamAV error: #{resp.error_str} for file #{file}. File not scanned!"
-      true # err on the side of trust? Need to think about this
+      false # err on the side of trust? Need to think about this
     else
       warn "ClamAV response unknown type '#{resp.class}': #{resp}. File not scanned!"
-      true
+      false
     end
   end
 

--- a/lib/umich_clamav_daemon_scanner.rb
+++ b/lib/umich_clamav_daemon_scanner.rb
@@ -48,7 +48,7 @@ class UMichClamAVDaemonScanner < Hydra::Works::VirusScanner
   # states (no virus or some sort of error)
   def infected?
     unless alive?
-      warning "Cannot connect to virus scanner. Skipping"
+      warning "Cannot connect to virus scanner. Skipping file #{file}"
       return false
     end
     resp = scan_response

--- a/lib/umich_clamav_daemon_scanner.rb
+++ b/lib/umich_clamav_daemon_scanner.rb
@@ -28,7 +28,6 @@ class UMichClamAVDaemonScanner < Hydra::Works::VirusScanner
                                           wrapper: ::ClamAV::Wrappers::NewLineWrapper.new)
       ClamAV::Client.new(connection)
     rescue Errno::ECONNREFUSED => e
-      puts "IN HERE!!!!"
       CannotConnectClient.new
     end
   end

--- a/lib/umich_clamav_daemon_scanner.rb
+++ b/lib/umich_clamav_daemon_scanner.rb
@@ -1,0 +1,113 @@
+#require 'clamav/client'
+
+# An AV class that streams the file to an already-running
+# clamav daemon
+class UMichClamAVDaemonScanner < Hydra::Works::VirusScanner
+
+
+  # standard umich clamav configuration (from /etc/clamav/clamav.conf)
+
+  CONNECTION_TYPE = :tcp
+  PORT            = 3310
+  MACHINE         = '127.0.0.1'
+
+  CHUNKSIZE = 4096
+
+  # Check to see if we can connect to the configured
+  # ClamAV daemon
+  def alive?
+    client.execute(ClamAV::Commands::PingCommand.new)
+    true
+  rescue Errno::ECONNREFUSED
+    false
+  end
+
+  # Check to see if the file passed on `#new` is infected
+  # Reports `true` if a virus is found, `false` for all other
+  # states (no virus or some sort of error)
+  def infected?
+    file_io = File.open(file, 'rb')
+    resp    = scan(file_io)
+    case resp
+    when ClamAV::SuccessResponse
+      info "Clean virus check for '#{file}'"
+      false
+    when ClamAV::VirusResponse
+      warn "Virus #{resp.virus_name} found in file '#{file}'"
+      true
+    when ClamAV::ErrorResponse
+      warn "ClamAV error: #{resp.error_str} for file #{file}. File not scanned!"
+      true # err on the side of trust? Need to think about this
+    else
+      warn "ClamAV response unknown type '#{resp.class}': #{resp}. File not scanned!"
+      true
+    end
+  end
+
+  # Do the scan by streaming to the daemon
+  # @param [#read] io The IO stream (probably an open file) to read from
+  # @return A ClamAV::*Response object
+  def scan(io)
+    cmd = UMInstreamScanner.new(io, CHUNKSIZE)
+    client.execute(cmd)
+  end
+
+
+
+
+  private
+  # Set up logging for the clamav daemon scanner
+  def info(msg)
+    ActiveFedora::Base.logger.info(msg) if ActiveFedora::Base.logger
+  end
+
+  def warning(msg)
+    ActiveFedora::Base.logger.warn(msg) if ActiveFedora::Base.logger
+  end
+
+end
+
+
+
+# Stream a file to the AV scanner in chucks to avoid
+# reading it all into memory. Internal to how
+# ClamAV::Client works
+class UMInstreamScanner < ClamAV::Commands::InstreamCommand
+  def call(conn)
+    conn.write_request("INSTREAM")
+    while(packet = @io.read(@max_chunk_size))
+      scan_packet(conn, packet)
+    end
+    send_end_of_file(conn)
+    av_return_status(conn)
+  rescue => e
+    ClamAV::ErrorResponse.new("Error sending data to ClamAV Daemon: #{e}")
+  end
+
+  def av_return_status(conn)
+    get_status_from_response(conn.read_response)
+  end
+
+  def send_end_of_file(conn)
+    conn.raw_write("\x00\x00\x00\x00")
+  end
+
+  def scan_packet(conn, packet)
+    packet_size = [packet.size].pack("N")
+    conn.raw_write("#{packet_size}#{packet}")
+  end
+
+
+end
+
+
+
+
+
+# To use a virus checker other than ClamAV:
+#   class MyScanner < Hydra::Works::VirusScanner
+#     def infected?
+#       my_result = Scanner.check_for_viruses(file)
+#       [return true or false]
+#     end
+#   end

--- a/spec/integration/clamav_daemon_spec.rb
+++ b/spec/integration/clamav_daemon_spec.rb
@@ -1,0 +1,28 @@
+require 'umich_clamav_daemon_scanner'
+
+RSpec.describe UMichClamAVDaemonScanner do
+
+  let(:clamd_running) {!!(/\S/.match(`pgrep clamd`))}
+
+  let(:basic_av_connection) { described_class.new(__FILE__) }
+
+  it "can scan a harmless file" do
+    skip("ClamAV Daemon not running") unless basic_av_connection.alive?
+    scanner = described_class.new(__FILE__)
+    expect(scanner.scan_response).to be_a(ClamAV::SuccessResponse)
+  end
+
+  it "reports an error on a bad file (directory in this case)" do
+    skip("ClamAV Daemon not running") unless basic_av_connection.alive?
+    scanner = described_class.new(__dir__)
+    expect(scanner.scan_response).to be_a(ClamAV::ErrorResponse)
+  end
+
+  it "errors out if the file doesn't exist" do
+    skip("ClamAV Daemon not running") unless basic_av_connection.alive?
+    scanner = described_class.new('asdfadsfasdfasdfasdf')
+    expect {scanner.infected?}.to raise_error(RuntimeError, /Can't open file/)
+  end
+
+
+end


### PR DESCRIPTION
Changes:
  * Add specs (will show up as "pending" if it doesn't detect
    clamd running)
  * Guard against non-running or non-functional clamd

Remaining issues/questions:
  * What should be the result if the daemon is down: report clean,
    or report infected? I assume the former
  * Should the 4GB check go in here?
  * Currently all UM-specific. We should dedicate some time to pull it out and control it with
    config settings