### PR TITLE
Redesign the search results page DBD-763

### DIFF
--- a/app/assets/stylesheets/custom_layout/tweaks.css
+++ b/app/assets/stylesheets/custom_layout/tweaks.css
@@ -6,7 +6,7 @@
     text-align: right;
 }
 /* Describe Data Form */
-#works_edit > h2.non.lower {
+h2.non.lower {
   text-align: center;
   background-color: #FAFAFA;
   padding: .75em;
@@ -148,4 +148,73 @@ div.radio p {
 
 .cancel-btn::after {
 content: ' X ';
+}
+
+/**** Search Results *****/
+
+#search-results ul.catalog {
+  list-style: none;
+}
+
+/*** Deposit Intro Page ****/
+
+.position-page {
+  max-width: 45em;
+  margin: 2em auto;
+  background: #fff;
+  text-align: center;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.12), 0 2px 4px 0 rgba(0,0,0,0.24);
+  padding-bottom: 1em;
+}
+
+.position-page h2{
+  padding-top: 1em;
+}
+
+.position-page .text-block {
+  text-align: center;
+  padding: 0 2.5em;
+}
+
+.position-page ul {
+  list-style: none;
+  padding: 1em 0;
+}
+
+.position-page ul li {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.position-page .input-group {
+  padding: .5em 3em;
+}
+
+span.icon.arrow:before {
+ content: url(https://www.lib.umich.edu/falafel/v0/icons/white/arrow_right.svg);
+  position: relative;
+  top: 6px;
+  display: inline-block;
+}
+
+.emphasis {
+  color: #126DC1;
+  margin: 0;
+  font-weight: 500;
+}
+
+.collection-icon-search {
+  color: #2C72B6;
+  font-size: 6em;
+ }
+
+/**** Utility Classes ****/
+
+.top-border {
+  border-top: 2px solid #E5E5E5;
+  padding: 1em 0;
+}
+
+.align-left {
+  text-align: left;
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -57,7 +57,7 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5
+    # config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5
     config.add_facet_field solr_name("creator", :facetable), label: "Creator", limit: 5
     config.add_facet_field solr_name("subject", :facetable), label: "Discipline", limit: 5
     config.add_facet_field solr_name("tag", :facetable), label: "Keywords", limit: 5
@@ -73,7 +73,8 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name'
+    # config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name'
+    config.index.thumbnail_field = 'thumbnail_path_ss'
     config.add_index_field solr_name("creator", :stored_searchable), label: "Creator", itemprop: 'creator'
     config.add_index_field solr_name("description", :stored_searchable), label: "Description", itemprop: 'description'
     config.add_index_field solr_name("date_uploaded", :stored_searchable), label: "Date Uploaded", itemprop: 'datePublished'

--- a/app/views/catalog/_document_list.html.erb
+++ b/app/views/catalog/_document_list.html.erb
@@ -1,0 +1,6 @@
+<%# container for all documents in index view -%>
+<div id="search-results">
+  <ul class="catalog" start="<%= document_counter_with_offset(0) %>">
+   <%= render documents, as: :document %>
+  </ul>
+</div>

--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,0 +1,12 @@
+<div class="panel panel-default facet_limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet_limit-active' if facet_field_in_params?(facet_field.key) %>">
+  <div class="<%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle panel-heading" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
+    <h3 class="panel-title facet-field-heading">
+      <%= link_to facet_field_label(facet_field.key), "#", :"data-no-turbolink" => true %>
+    </h3>
+  </div>
+  <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'in' : 'collapse' %>">
+    <div class="panel-body">
+      <%= yield %>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,4 +1,4 @@
-    <div class="col-sm-12">
+    <div class="col-sm-9">
       <table class="table">
         <% doc_presenter = index_presenter(document) %>
         <% index_fields(document).each do |field_name, field| -%>

--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -4,7 +4,7 @@
   <div class="view-type-group btn-group">
     <%  document_index_views.each do |view, config| %>
       <%= link_to url_for(search_state.to_h.merge(view: view)), title: view_label(view), class: "btn btn-default view-type-#{ view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
-        <%= render_view_type_group_icon view %>
+        <%#= render_view_type_group_icon view %>
         <span><%= view_label(view) %></span>
       <% end %>
     <% end %>


### PR DESCRIPTION
Search results page redesigned to remove list numbers, duplicate title, keep the facet box open, and get rid of the resource type. 