### PR TITLE
DBD-895 Filter out .csv files from characterization

### DIFF
--- a/app/helpers/characterization_helper.rb
+++ b/app/helpers/characterization_helper.rb
@@ -1,0 +1,122 @@
+
+module CharacterizationHelper
+
+  # @param [FileSet] file_set
+  # @param [String] file_id identifier for a Hydra::PCDM::File
+  # @param [String, NilClass] file_path the cached file within the Hyrax.config.working_path
+  def self.characterize( file_set,
+                         file_id,
+                         file_path = nil,
+                         delete_input_file: true,
+                         continue_job_chain: true,
+                         continue_job_chain_later: true )
+    file_name = Hyrax::WorkingDirectory.find_or_retrieve( file_id, file_set.id, file_path )
+    file_ext = File.extname file_set.label
+    if Umrdr::Application.config.characterize_excluded_ext_set.has_key? file_ext
+      Rails.logger.info "Skipping characterization of file with extension #{file_ext}: #{file_name}"
+      perform_create_derivatives_job( file_set,
+                                      file_id,
+                                      file_name,
+                                      delete_input_file: delete_input_file,
+                                      continue_job_chain: continue_job_chain,
+                                      continue_job_chain_later: continue_job_chain_later )
+      return
+    end
+    unless file_set.characterization_proxy?
+      error_msg = "#{file_set.class.characterization_proxy} was not found"
+      Rails.logger.error error_msg
+      raise LoadError, error_msg
+    end
+    begin
+      proxy = file_set.characterization_proxy
+      Hydra::Works::CharacterizationService.run( proxy, file_name )
+      Rails.logger.debug "Ran characterization on #{proxy.id} (#{proxy.mime_type})"
+      file_set.characterization_proxy.save!
+      file_set.update_index
+      file_set.parent.in_collections.each(&:update_index) if file_set.parent
+    rescue Exception => e
+      Rails.logger.error "CharacterizationHelper.create_derivatives(#{file_name}) #{e.class}: #{e.message}"
+    ensure
+      perform_create_derivatives_job( file_set,
+                                      file_id,
+                                      file_name,
+                                      delete_input_file: delete_input_file,
+                                      continue_job_chain: continue_job_chain,
+                                      continue_job_chain_later: continue_job_chain_later )
+    end
+  end
+
+  # @param [FileSet] file_set
+  # @param [String] file_id identifier for a Hydra::PCDM::File
+  # @param [String, NilClass] file_path the cached file within the Hyrax.config.working_path
+  def create_derivatives( file_set, file_id, file_path = nil, delete_input_file: true )
+    file_name = Hyrax::WorkingDirectory.find_or_retrieve( file_id, file_set.id, file_path )
+    Rails.logger.warn "Create derivatives for: #{file_name}."
+    begin
+      file_ext = File.extname file_set.label
+      if Umrdr::Application.config.derivative_excluded_ext_set.has_key? file_ext
+        Rails.logger.info "Skipping derivative of file with extension #{file_ext}: #{file_name}"
+        return
+      end
+      if file_set.video? && !Hyrax.config.enable_ffmpeg
+        Rails.logger.info "Skipping video derivative job for file: #{file_name}"
+        return
+      end
+      threshold_file_size = Umrdr::Application.config.derivative_max_file_size
+      if threshold_file_size > -1 && File.exist?(file_name) && File.size(file_name) > threshold_file_size
+        human_readable = ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert( threshold_file_size, precision: 3 )
+        Rails.logger.info "Skipping file larger than #{human_readable} for create derivative job file: #{file_name}"
+        return
+      end
+      Rails.logger.debug "About to call create derivatives: #{file_name}."
+      file_set.create_derivatives(file_name)
+      Rails.logger.debug "Create derivatives successful: #{file_name}."
+      # Reload from Fedora and reindex for thumbnail and extracted text
+      file_set.reload
+      file_set.update_index
+      file_set.parent.update_index if parent_needs_reindex?(file_set)
+      Rails.logger.debug "Successful create derivative job for file: #{file_name}"
+      #delete_file( file_path, delete_file_flag: delete_input_file, msg_prefix: 'Create derivatives ' )
+    rescue Exception => e
+      Rails.logger.error "CharacterizationHelper.create_derivatives(#{file_set},#{file_id},#{file_path}) #{e.class}: #{e.message}"
+    ensure
+      #This is the last step in the process ( ingest job -> characterization job -> create derivative (last step))
+      #So now it's safe to remove the file uploaded file.
+      delete_file( file_path, delete_file_flag: delete_input_file, msg_prefix: 'Create derivatives ' )
+    end
+  end
+
+  def self.delete_file( file_path, delete_file_flag: false, msg_prefix: '' )
+    if delete_file_flag
+      if File.exist? file_path
+        File.delete file_path
+        Rails.logger.debug "#{msg_prefix}file deleted: #{file_path}"
+      end
+    end
+  end
+
+  # If this file_set is the thumbnail for the parent work,
+  # then the parent also needs to be reindexed.
+  def parent_needs_reindex?(file_set)
+    return false unless file_set.parent
+    file_set.parent.thumbnail_id == file_set.id
+  end
+
+  def self.perform_create_derivatives_job( file_set,
+                                           file_id,
+                                           file_name,
+                                           delete_input_file: true,
+                                           continue_job_chain: true,
+                                           continue_job_chain_later: true )
+    if continue_job_chain
+      if continue_job_chain_later
+        CreateDerivativesJob.perform_later( file_set, file_id, file_name, delete_input_file )
+      else
+        CreateDerivativesJob.perform_now( file_set, file_id, file_name, delete_input_file )
+      end
+    else
+      delete_file( file_path, delete_file_flag: delete_input_file, msg_prefix: 'Characterize ' )
+    end
+  end
+
+end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,38 +1,44 @@
+include CharacterizationHelper
+
 class CharacterizeJob < ActiveJob::Base
   queue_as Hyrax.config.ingest_queue_name
 
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
-  def perform(file_set, file_id, filepath = nil)
-    filename = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
-    #Rails.logger.warn "File to characterize: " + filepath
-    ## TO DO: put in a config file?
-    ## nc files will can't be retrieved if they go through characterization.
-    #if file_set.label.end_with?(".nc")
-    #  if File.exist?(filepath)
-    #    File.delete (filepath)
-    #    Rails.logger.debug "Characterize file deleted: " + filepath
-    #  end
-    #  return
-    #end
-    unless file_set.characterization_proxy?
-      error_msg = "#{file_set.class.characterization_proxy} was not found"
-      Rails.logger.error error_msg
-      raise LoadError, error_msg
-    end
-    begin
-      Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filename)
-      Rails.logger.debug "Ran characterization on " \
-            + "#{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
-      file_set.characterization_proxy.save!
-      file_set.update_index
-      file_set.parent.in_collections.each(&:update_index) if file_set.parent
-    rescue Exception => e
-      Rails.logger.error "create_derivatives(#{filename}) #{e.class}: #{e.message}"
-    ensure
-      # the create derivatives job will delete the input temp file
-      CreateDerivativesJob.perform_later(file_set, file_id, filename)
-    end
+  def perform( file_set, file_id, filepath = nil, delete_input_file = true )
+    CharacterizationHelper.characterize( file_set, file_id, filepath, delete_input_file: delete_input_file )
+  rescue Exception => e
+    Rails.logger.error "CharacterizeJob.perform(#{file_set},#{file_id},#{filepath}) #{e.class}: #{e.message}"
+    # filename = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
+    # #Rails.logger.warn "File to characterize: " + filepath
+    # ## TO DO: put in a config file?
+    # ## nc files will can't be retrieved if they go through characterization.
+    # #if file_set.label.end_with?(".nc")
+    # #  if File.exist?(filepath)
+    # #    File.delete (filepath)
+    # #    Rails.logger.debug "Characterize file deleted: " + filepath
+    # #  end
+    # #  return
+    # #end
+    # unless file_set.characterization_proxy?
+    #   error_msg = "#{file_set.class.characterization_proxy} was not found"
+    #   Rails.logger.error error_msg
+    #   raise LoadError, error_msg
+    # end
+    # begin
+    #   Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filename)
+    #   Rails.logger.debug "Ran characterization on " \
+    #         + "#{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
+    #   file_set.characterization_proxy.save!
+    #   file_set.update_index
+    #   file_set.parent.in_collections.each(&:update_index) if file_set.parent
+  # rescue Exception => e
+  #   Rails.logger.error "create_derivatives(#{filename}) #{e.class}: #{e.message}"
+    # ensure
+    #   # the create derivatives job will delete the input temp file
+    #   CreateDerivativesJob.perform_later(file_set, file_id, filename, delete_input_file )
+    # end
   end
+
 end

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -1,48 +1,53 @@
+include CharacterizationHelper
+
 class CreateDerivativesJob < ActiveJob::Base
   queue_as Hyrax.config.ingest_queue_name
 
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
-  def perform(file_set, file_id, filepath = nil)
-    filename = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
-    Rails.logger.warn "Create derivatives for: #{filename}."
-    begin
-      if file_set.video? && !Hyrax.config.enable_ffmpeg
-        Rails.logger.info "Skipping video derivative job for file: #{filename}"
-        return
-      end
-      threshold_file_size = Umrdr::Application.config.max_derivative_file_size
-      if threshold_file_size > -1 && File.exist?(filename) && File.size(filename) > threshold_file_size
-        human_readable = ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert( threshold_file_size, precision: 3 )
-        Rails.logger.info "Skipping file larger than #{human_readable} for create derivative job file: #{filename}"
-        return
-      end
-      Rails.logger.debug "About to call create derivatives: #{filename}."
-      file_set.create_derivatives(filename)
-      Rails.logger.debug "Create derivatives successful: #{filename}."
-      # Reload from Fedora and reindex for thumbnail and extracted text
-      file_set.reload
-      file_set.update_index
-      file_set.parent.update_index if parent_needs_reindex?(file_set)
-      Rails.logger.debug "Successful create derivative job for file: #{filename}"
-    rescue Exception => e
-      Rails.logger.error "CreateDerivativesJob.perform(#{file_set},#{file_id},#{filepath}) #{e.class}: #{e.message}"
-    ensure
-      #This is the last step in the process ( ingest job -> characterization job -> create derivative (last step))
-      #So now it's safe to remove the file uploaded file.
-      if File.exist?(filepath)
-        File.delete (filepath)
-        Rails.logger.info "Create derivatives file deleted: #{filepath}"
-      end
-    end
+  def perform( file_set, file_id, filepath = nil, delete_input_file = true )
+    CharacterizationHelper.create_derivatives( file_set, file_id, filepath, delete_input_file: delete_input_file )
+  rescue Exception => e
+    Rails.logger.error "CreateDerivativesJob.perform(#{file_set},#{file_id},#{filepath}) #{e.class}: #{e.message}"
+    # filename = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
+    # Rails.logger.warn "Create derivatives for: #{filename}."
+    # begin
+    #   if file_set.video? && !Hyrax.config.enable_ffmpeg
+    #     Rails.logger.info "Skipping video derivative job for file: #{filename}"
+    #     return
+    #   end
+    #   threshold_file_size = Umrdr::Application.config.derivative_max_file_size
+    #   if threshold_file_size > -1 && File.exist?(filename) && File.size(filename) > threshold_file_size
+    #     human_readable = ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert( threshold_file_size, precision: 3 )
+    #     Rails.logger.info "Skipping file larger than #{human_readable} for create derivative job file: #{filename}"
+    #     return
+    #   end
+    #   Rails.logger.debug "About to call create derivatives: #{filename}."
+    #   file_set.create_derivatives(filename)
+    #   Rails.logger.debug "Create derivatives successful: #{filename}."
+    #   # Reload from Fedora and reindex for thumbnail and extracted text
+    #   file_set.reload
+    #   file_set.update_index
+    #   file_set.parent.update_index if parent_needs_reindex?(file_set)
+    #   Rails.logger.debug "Successful create derivative job for file: #{filename}"
+  # rescue Exception => e
+  #   Rails.logger.error "CreateDerivativesJob.perform(#{file_set},#{file_id},#{filepath}) #{e.class}: #{e.message}"
+    # ensure
+    #   #This is the last step in the process ( ingest job -> characterization job -> create derivative (last step))
+    #   #So now it's safe to remove the file uploaded file.
+    #   if File.exist?(filepath)
+    #     File.delete (filepath)
+    #     Rails.logger.info "Create derivatives file deleted: #{filepath}"
+    #   end
+    # end
   end
 
-  # If this file_set is the thumbnail for the parent work,
-  # then the parent also needs to be reindexed.
-  def parent_needs_reindex?(file_set)
-    return false unless file_set.parent
-    file_set.parent.thumbnail_id == file_set.id
-  end
+  # # If this file_set is the thumbnail for the parent work,
+  # # then the parent also needs to be reindexed.
+  # def parent_needs_reindex?(file_set)
+  #   return false unless file_set.parent
+  #   file_set.parent.thumbnail_id == file_set.id
+  # end
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,11 +43,16 @@ module Umrdr
     config.max_total_file_size = config.max_file_size * 5
     config.max_total_file_size_str = ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert(config.max_total_file_size, {})
 
-    config.max_derivative_file_size = 4_000_000_000 # set to -1 for no limit
-    config.max_derivative_file_size_str = ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert( config.max_derivative_file_size, precision: 3 )
-
     config.max_work_file_size_to_download = 10_000_000_000
     config.min_work_file_size_to_download_warn = 1_000_000_000
+
+    # ingest characterization config
+    config.characterize_excluded_ext_set = { '.csv' => 'text/plain' }.freeze
+
+    # ingest derivative config
+    config.derivative_excluded_ext_set = {}.freeze
+    config.derivative_max_file_size = 4_000_000_000 # set to -1 for no limit
+    config.derivative_max_file_size_str = ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert(config.derivative_max_file_size, precision: 3 )
 
     # Deploy to /data instead of /
     config.relative_url_root = '/data' unless Rails.env.test?


### PR DESCRIPTION
Moved guts of characterization and derivatives to helper and added
config variables to track file extensions not to characterized or
have derivatives generated.