### PR TITLE
DBD-943 Move DBD agreement to works description

### DIFF
--- a/app/views/hyrax/file_sets/upload/_agreement.html.erb
+++ b/app/views/hyrax/file_sets/upload/_agreement.html.erb
@@ -1,5 +1,2 @@
-<div class="alert alert-info">
-  <strong>Note:</strong> You must agree to the <a href="<%= hyrax.terms_path(:terms) %>" target="_blank"><%= t('hyrax.deposit_agreement') %></a> before starting your upload.
+	<strong>Note:</strong> You must agree to the <a href="<%= hyrax.terms_path(:terms) %>" target="_blank"><%= t('hyrax.deposit_agreement') %></a> before saving your deposit.
 </div>
-
-

--- a/app/views/hyrax/file_sets/upload/_form_fields.html.erb
+++ b/app/views/hyrax/file_sets/upload/_form_fields.html.erb
@@ -9,10 +9,6 @@
 <%= hidden_field_tag(:parent_id, @work_id) %>
 <%= hidden_field_tag "file_coming_from", "local" %>
 
-<div class="upload-terms-of-service">
-  <%= render 'hyrax/file_sets/upload/tos_checkbox' %>
-  <%= render 'hyrax/file_sets/upload/agreement' %>
-</div>
 
 <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
 <div class="fileupload-buttonbar">
@@ -30,8 +26,8 @@
     <input type="file" name="file_set[files][]" directory webkitdirectory mozdirectory />
   </span>
   <% end %>
-  <div id="main_upload_start_span"  class="activate-container visible-all-inline-block" data-toggle="tooltip" data-title="<%= t('hyrax.upload_tooltip') %>">
-    <button disabled type="submit" name="main_upload_start" class="activate-submit btn btn-info start"   id="main_upload_start">
+  <div class="activate-container visible-all-inline-block" data-toggle="tooltip" data-title="<%= t('hyrax.upload_tooltip') %>">
+    <button type="submit"  class="activate-submit btn btn-info start"  >
       <i class="glyphicon glyphicon-upload"></i>
       <span>Start upload</span>
     </button>

--- a/app/views/hyrax/file_sets/upload/_tos_checkbox.html.erb
+++ b/app/views/hyrax/file_sets/upload/_tos_checkbox.html.erb
@@ -1,5 +1,4 @@
-<p>
-<label>
-  <%= check_box_tag 'terms_of_service', 1, nil, required: "required", onchange: "document.getElementById('main_upload_start').disabled = !this.checked;" %><strong> I have read and do agree to the <%= link_to t('hyrax.deposit_agreement'), hyrax.terms_path(:terms), target: "_blank" %>.</strong>
-</label>
-</p>
+<div class="form-group">
+	<p><label>
+	  <%= check_box_tag 'terms_of_service', 1, nil, required: "required" %><strong> I have read and do agree to the <%= link_to t('hyrax.deposit_agreement'), hyrax.terms_path(:terms), target: "_blank" %>.</strong></label>
+	</p>

--- a/app/views/records/edit_fields/_visibility.html.erb
+++ b/app/views/records/edit_fields/_visibility.html.erb
@@ -37,11 +37,16 @@
 </p>
 <% end %>-->
 
+<div class="upload-terms-of-service">
+  <%= render 'hyrax/file_sets/upload/tos_checkbox' %>
+  <%= render 'hyrax/file_sets/upload/agreement' %>
+</div>
+
 <div class="data-buttons">
 <%= hidden_field_tag(:isDraft, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
 <%= f.submit 'Save as Draft (Private)', class: 'btn btn-default', onclick: "confirmation_needed = false; document.getElementById('isDraft').value = '#{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE}';", id: "with_files_submit", name: "save_with_files" %>
 
-<%= f.submit 'Save Description (Public)', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+<%= f.submit 'Save Description (Public)', class: 'btn btn-primary', onclick: "confirmation_needed = false; document.getElementById('isDraft').value = '#{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC}';", id: "with_files_submit", name: "save_with_files" %>
 <br>
   <%= link_to t(:'helpers.action.cancel'), curation_concern.new_record? ? main_app.root_path : polymorphic_path([main_app, curation_concern]), class: 'btn btn-link cancel-btn' %>
 </div>


### PR DESCRIPTION
- DBD agreement checkbox moved to Works Description form. Required upon saving the deposit.
- Updated the text in the warning/note. (before upload -> before saving deposit)
- Also enabled the upload button in the Upload well group as it was previously dependent on the TOS checkbox. (This will all be eliminated in DBD-944 anyway but making it usable in the meantime.)