### PR TITLE
Remove unnecessary top-level includes

### DIFF
--- a/app/controllers/hyrax/generic_works_controller.rb
+++ b/app/controllers/hyrax/generic_works_controller.rb
@@ -1,6 +1,4 @@
 require 'edtf'
-include EmailHelper
-include MsgHelper
 
 class Hyrax::GenericWorksController < ApplicationController
 
@@ -124,7 +122,7 @@ class Hyrax::GenericWorksController < ApplicationController
   end
 
   def confirm
-    render 'confirm_work' 
+    render 'confirm_work'
   end
 
   ## begin download operations

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -1,6 +1,3 @@
-
-include OrderedStringHelper
-
 module MetadataHelper
 
   @@FIELD_SEP = '; '.freeze

--- a/app/helpers/msg_helper.rb
+++ b/app/helpers/msg_helper.rb
@@ -1,5 +1,5 @@
 module MsgHelper
-  include ActionView::Helpers::TranslationHelper
+  extend ActionView::Helpers::TranslationHelper
 
   @@FIELD_SEP = '; '.freeze
 
@@ -21,14 +21,6 @@ module MsgHelper
 
   def self.subject( curration_concern, field_sep: @@FIELD_SEP )
     curration_concern.subject.join( field_sep )
-  end
-
-  def self.t( key, options = {} )
-    ActionView::Helpers::TranslationHelper.t( key, options )
-  end
-
-  def self.translate( key, options = {} )
-    ActionView::Helpers::TranslationHelper.translate( key, options )
   end
 
   def self.title( curration_concern, field_sep: @@FIELD_SEP )

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,5 +1,3 @@
-include CharacterizationHelper
-
 class CharacterizeJob < ActiveJob::Base
   queue_as Hyrax.config.ingest_queue_name
 

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -1,5 +1,3 @@
-include CharacterizationHelper
-
 class CreateDerivativesJob < ActiveJob::Base
   queue_as Hyrax.config.ingest_queue_name
 

--- a/app/jobs/globus_copy_job.rb
+++ b/app/jobs/globus_copy_job.rb
@@ -1,5 +1,3 @@
-include EmailHelper
-
 class GlobusCopyJob < GlobusJob
   queue_as :globus_copy
 

--- a/app/mailers/work_mailer.rb
+++ b/app/mailers/work_mailer.rb
@@ -1,10 +1,8 @@
-include EmailHelper
-
 class WorkMailer < ApplicationMailer
   default from: EmailHelper.notification_email
 
   layout "mailer.html"
- 
+
   def create_work( to: EmailHelper.notification_email, from: EmailHelper.notification_email, body: '' )
     mail( to: to, from: from, subject: 'DBD: New Work Created', body: body )
   end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,6 +1,3 @@
-
-include MetadataHelper
-
 class Collection < ActiveFedora::Base
   include ::Hyrax::CollectionBehavior
   # You can replace these metadata if they're not suitable
@@ -8,7 +5,7 @@ class Collection < ActiveFedora::Base
   include Umrdr::GenericWorkMetadata
 
   after_initialize :set_defaults
-  
+
   # property :isReferencedBy, predicate: ::RDF::Vocab::DC.isReferencedBy, multiple: true do |index|
   #  index.type :text
   #  index.as :stored_searchable
@@ -103,4 +100,4 @@ class Collection < ActiveFedora::Base
     super values
   end
 
-end 
+end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -1,6 +1,3 @@
-
-include MetadataHelper
-
 class GenericWork < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::Hyrax::BasicMetadata

--- a/lib/provenance_logger.rb
+++ b/lib/provenance_logger.rb
@@ -1,6 +1,3 @@
-# lib/custom_logger.rb
-include EmailHelper
-
 class ProvenanceLogger < Logger
   def format_message(severity, timestamp, progname, msg)
     "#{timestamp.to_formatted_s(:db)} #{severity} User: #{EmailHelper.user_email} #{msg}\n"

--- a/spec/features/create_generic_work_spec.rb
+++ b/spec/features/create_generic_work_spec.rb
@@ -1,10 +1,8 @@
-# Generated via
-#  `rails generate curation_concerns:work GenericWork`
 require 'rails_helper'
-include Warden::Test::Helpers
 
 # Skipping because this was failing intermittently on travis (same as create_work_spec from upstream)
 RSpec.feature 'Create a GenericWork', :workflow, skip: true do
+  include Warden::Test::Helpers
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }
@@ -23,7 +21,7 @@ RSpec.feature 'Create a GenericWork', :workflow, skip: true do
       fill_in 'Creator', with: 'Creator, Test'
       fill_in 'Method', with: 'Test'
       fill_in 'Description', with: 'Test'
-      fill_in 'Contact Information', with: 'abc@umich.edu' 
+      fill_in 'Contact Information', with: 'abc@umich.edu'
       choose 'generic_work_rights_httpcreativecommonsorgpublicdomainzero10'
       select 'Other', from: 'generic_work_subject'
       click_button 'Publish'


### PR DESCRIPTION
Seeing "include SomeClassorModule" outside of any scope is surprising
in ruby land, and has a side-effect on the global namespace. These
were primarily functioning as "require" statements. We opted to delete
them instead of replacing them with "requires" because rails autoloading
is already loading the files, and the autoloading convention is being
followed project wide.