### PR TITLE
Move #tombstone logic to GenericWork#entomb!

### DIFF
--- a/app/controllers/hyrax/generic_works_controller.rb
+++ b/app/controllers/hyrax/generic_works_controller.rb
@@ -104,19 +104,7 @@ class Hyrax::GenericWorksController < ApplicationController
   end
 
   def tombstone
-    #Make it so work does not show up in search result for anyone, not even admins.
-    curation_concern.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-    curation_concern.depositor = 'TOMBSTONE-' +   curation_concern.depositor
-
-    #I tried this but it did not work.  And gets complicated.
-    #curation_concern.state = Vocab::FedoraResourceStatus.inactive
-
-    for i in 0 ... curation_concern.file_sets.size
-      curation_concern.file_sets[i].visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-    end
-
-    curation_concern.tombstone = [params[:tombstone]]
-    curation_concern.save
+    curation_concern.entomb!(params[:tombstone])
     redirect_to dashboard_works_path,
                 notice: MsgHelper.t( 'generic_work.tombstone_notice',
                                      title: "#{curation_concern.title.first}",
@@ -124,7 +112,7 @@ class Hyrax::GenericWorksController < ApplicationController
   end
 
   def confirm
-    render 'confirm_work' 
+    render 'confirm_work'
   end
 
   ## begin download operations

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -62,6 +62,21 @@ class GenericWork < ActiveFedora::Base
   end
 
   #
+  # Make it so work does not show up in search result for anyone, not even admins.
+  #
+  def entomb!(epitaph)
+    self.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    self.depositor = 'TOMBSTONE-' + depositor
+    self.tombstone = epitaph
+
+    file_sets.each do |file_set|
+      file_set.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+
+    save
+  end
+
+  #
   # handle the list of isReferencedBy as ordered
   #
   def isReferencedBy


### PR DESCRIPTION
Note: There were no existing tests for this portion of the code, but it looks like it should be easy to add for someone more familiar with the behavior of GenericWork.

The Hyrax::GenericWorksController#tombstone method reached into
the GenericWork to manipulate its values.

This commit moves the logic of what it means to tombstone a GenericWork
into the GenericWork class itself. The controller is then able to
delegate to the model with one line.

This is not a functional change.