### PR TITLE
Addresses #1035 by enabling folder selection in non-Chrome browsers.

### DIFF
--- a/app/views/hyrax/file_sets/upload/_form_fields.html.erb
+++ b/app/views/hyrax/file_sets/upload/_form_fields.html.erb
@@ -22,14 +22,11 @@
       <span aria-hidden="true">Select files...</span>
       <input type="file" name="file_set[files][]" multiple />
     </span>
-    <% ua = request.env['HTTP_USER_AGENT'] %>
-    <% if !!(ua =~ /Chrome/) %>
     <span class="btn btn-primary fileinput-button">
       <i class="glyphicon glyphicon-plus"  aria-hidden="true"></i>
       <span aria-hidden="true">Select folder...</span>
       <input type="file" name="file_set[files][]" directory webkitdirectory mozdirectory />
     </span>
-    <% end %>
     <div id="main_upload_start_span"
          class="activate-container visible-all-inline-block"
          data-toggle="tooltip"


### PR DESCRIPTION
Folder upload on Chrome is almost as flakey as Firefox in my dev environment but this puts them on equal footing.