### PR TITLE
Addresses DBD-1032 tombstone caption MIA in Firefox.

### DIFF
--- a/app/assets/stylesheets/custom_layout/tweaks.css
+++ b/app/assets/stylesheets/custom_layout/tweaks.css
@@ -338,3 +338,7 @@ div.panel-body {
   }
 
 }
+
+th.alert-warning {
+  font-weight: normal;
+}

--- a/app/views/hyrax/base/_attributes.html.erb
+++ b/app/views/hyrax/base/_attributes.html.erb
@@ -21,12 +21,12 @@ if @presenter.editor? %>
 <div class="panel panel-default">
     <table class="table table-striped <%= dom_class(@presenter) %> attributes work-description" <%= @presenter.microdata_type_to_html %>>
       <caption class="table-heading"><h2>Work Description</h2></caption>
-      
-      <% if @presenter.tombstone.present? %>
-        <caption class="alert-warning"><%= t( 'generic_work.tombstoned', reason: @presenter.tombstone ) %></caption>
-      <% end %>
-
       <thead>
+        <% if @presenter.tombstone.present? %>
+          <tr>
+            <th class="alert-warning" colspan="2"><%= t( 'generic_work.tombstoned', reason: @presenter.tombstone ) %></th>
+          </tr>
+        <% end %>
         <tr><th colspan="2">Title: <%= @presenter.title.join(", ") %></th></tr>
         <tr><th>Attribute Name</th><th>Values</th></tr>
       </thead>


### PR DESCRIPTION
Move second <caption> for tombstone into <tr><th> so it is not discarded as redundant.