### PR TITLE
DBD-1071 - Add baseline OK Computer setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,4 +104,5 @@ gem 'devise'
 gem 'devise-guests'
 
 gem 'skylight'
+gem 'okcomputer', '~> 1.17'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -540,6 +540,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    okcomputer (1.17.2)
     om (3.1.1)
       activemodel
       activesupport
@@ -883,6 +884,7 @@ DEPENDENCIES
   mail_form
   mysql2 (~> 0.4.10)
   net-ldap
+  okcomputer (~> 1.17)
   poltergeist
   pry
   pry-byebug

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+OkComputer.mount_at = 'status'
+
+OkComputer.logger = Logger.new('log/status.log')


### PR DESCRIPTION
This is a minimal addition of OK Computer. It only does the default
check of the app and database. To be richer, it should be extended to
include specific checks for Fedora and Solr.